### PR TITLE
feat(moneygram-ramp): add MoneyGram cash off-ramp example

### DIFF
--- a/examples/moneygram-ramp/.env.example
+++ b/examples/moneygram-ramp/.env.example
@@ -1,0 +1,15 @@
+# Dynamic Labs Environment ID
+# Get from: https://app.dynamic.xyz/dashboard/developer/api
+# Enable: EVM + Solana embedded wallets, email OTP auth
+NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID=your_environment_id
+
+# MoneyGram Ramps API Key
+# Sandbox prefix: ramps_pk_sbox_
+# Your origin (domain + port) must be allowlisted by MoneyGram
+NEXT_PUBLIC_MG_RAMP_KEY=ramps_pk_sbox_your_key
+
+# Solana Devnet RPC URL (e.g. Helius, QuickNode, or public devnet)
+NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com
+
+# USDC SPL token mint address (devnet or mainnet depending on your environment)
+NEXT_PUBLIC_SOLANA_USDC_MINT=4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU

--- a/examples/moneygram-ramp/app/globals.css
+++ b/examples/moneygram-ramp/app/globals.css
@@ -1,0 +1,17 @@
+@import "tailwindcss";
+
+:root {
+  --background: #030712;
+  --foreground: #f9fafb;
+}
+
+body {
+  color: var(--foreground);
+  background: var(--background);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/examples/moneygram-ramp/app/layout.tsx
+++ b/examples/moneygram-ramp/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { Providers } from "./providers";
+import { Header } from "@/components/header";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Cash Pickup — Dynamic Demo",
+  description: "Convert USDC to cash at pickup locations worldwide using embedded wallets on Base, Ethereum, or Solana",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>
+          <Header />
+          {children}
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/examples/moneygram-ramp/app/page.tsx
+++ b/examples/moneygram-ramp/app/page.tsx
@@ -1,0 +1,5 @@
+import { RampApp } from "@/components/ramp-app";
+
+export default function Home() {
+  return <RampApp />;
+}

--- a/examples/moneygram-ramp/app/providers.tsx
+++ b/examples/moneygram-ramp/app/providers.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Toaster } from "sonner";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <Toaster position="bottom-center" theme="dark" />
+    </>
+  );
+}

--- a/examples/moneygram-ramp/components/cash-pickup-widget.tsx
+++ b/examples/moneygram-ramp/components/cash-pickup-widget.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+/**
+ * Cash Pickup Widget
+ *
+ * Full-screen iframe that handles the entire off-ramp flow internally.
+ * Handles the postMessage protocol on your app's side:
+ *
+ *   RAMPS_READY → RAMPS_CONFIG
+ *   RAMPS_CHECK_BALANCE → RAMPS_BALANCE_RESULT  (fetches on-chain USDC balance)
+ *   RAMPS_SIGN_TRANSACTION → RAMPS_SIGN_SUCCESS | RAMPS_SIGN_ERROR  (signs + broadcasts)
+ *   RAMPS_TRANSACTION_COMPLETE → onSuccess + onClose
+ *   RAMPS_CLOSE → onClose
+ *   RAMPS_OPEN_URL → window.open
+ *
+ * Supports Base, Ethereum, and Solana. The active chain is sent in RAMPS_CONFIG;
+ * payload.chain in each incoming message is used for balance/signing dispatch.
+ */
+
+import { useEffect, useRef } from "react";
+import type { WalletAccount } from "@dynamic-labs-sdk/client";
+import { isEvmWalletAccount } from "@dynamic-labs-sdk/evm";
+import { isSolanaWalletAccount } from "@dynamic-labs-sdk/solana";
+import { CHAINS, type MgChain } from "@/lib/chains";
+import { fetchUsdcBalance } from "@/lib/balance";
+import { sendUsdc } from "@/lib/send-usdc";
+import { env } from "@/lib/env";
+
+const WIDGET_ORIGIN = "https://d3em1tdv304u3f.cloudfront.net";
+const API_BASE_URL = "https://zq4rdvdd9j.execute-api.us-east-2.amazonaws.com";
+
+interface CashPickupWidgetProps {
+  open: boolean;
+  selectedChain: MgChain;
+  walletAccounts: WalletAccount[];
+  onClose: () => void;
+  onSuccess?: (amount: number) => void;
+}
+
+function getAddressForChain(chain: MgChain, accounts: WalletAccount[]): string {
+  if (chain === "solana") return accounts.find(isSolanaWalletAccount)?.address ?? "";
+  return accounts.find(isEvmWalletAccount)?.address ?? "";
+}
+
+export function CashPickupWidget({
+  open,
+  selectedChain,
+  walletAccounts,
+  onClose,
+  onSuccess,
+}: CashPickupWidgetProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const selectedChainRef = useRef(selectedChain);
+  const walletAccountsRef = useRef(walletAccounts);
+  const onCloseRef = useRef(onClose);
+  const onSuccessRef = useRef(onSuccess);
+  const pendingAmountRef = useRef(0);
+
+  useEffect(() => { selectedChainRef.current = selectedChain; }, [selectedChain]);
+  useEffect(() => { walletAccountsRef.current = walletAccounts; }, [walletAccounts]);
+  useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
+  useEffect(() => { onSuccessRef.current = onSuccess; }, [onSuccess]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function post(type: string, payload?: unknown) {
+      iframeRef.current?.contentWindow?.postMessage(
+        payload ? { type, payload } : { type },
+        WIDGET_ORIGIN,
+      );
+    }
+
+    async function handleMessage(event: MessageEvent) {
+      if (event.origin !== WIDGET_ORIGIN) return;
+
+      const { type, payload } = (event.data ?? {}) as {
+        type: string;
+        payload: Record<string, unknown>;
+      };
+
+      switch (type) {
+        case "RAMPS_READY": {
+          const chain = selectedChainRef.current;
+          const address = getAddressForChain(chain, walletAccountsRef.current);
+          post("RAMPS_CONFIG", {
+            apiKey: env.NEXT_PUBLIC_MG_RAMP_KEY,
+            wallet: {
+              address,
+              chain,
+              asset: "USDC",
+              walletType: "non-custodial",
+            },
+            devConfig: {
+              mockMode: false,
+              apiBaseUrl: API_BASE_URL,
+              apiVersion: "v2",
+            },
+            theme: "dark",
+          });
+          break;
+        }
+
+        case "RAMPS_CHECK_BALANCE": {
+          const chain = (payload?.chain as MgChain) ?? selectedChainRef.current;
+          const address = getAddressForChain(chain, walletAccountsRef.current);
+          const requestedAmount = (payload?.amount as number) ?? 0;
+          const balance = await fetchUsdcBalance(chain, address);
+          post("RAMPS_BALANCE_RESULT", {
+            walletAddress: address,
+            balance,
+            asset: "USDC",
+            sufficient: balance >= requestedAmount,
+          });
+          break;
+        }
+
+        case "RAMPS_SIGN_TRANSACTION": {
+          const chain = (payload?.chain as MgChain) ?? selectedChainRef.current;
+          const to = (payload?.to as string) ?? "";
+          const amount = parseFloat((payload?.amount as string) ?? "0");
+          try {
+            const hash = await sendUsdc({
+              to,
+              amount: String(amount),
+              chain,
+              walletAccounts: walletAccountsRef.current,
+            });
+            pendingAmountRef.current = amount;
+            post("RAMPS_SIGN_SUCCESS", { txHash: hash });
+          } catch (err) {
+            post("RAMPS_SIGN_ERROR", {
+              error: err instanceof Error ? err.message : "Transaction failed",
+            });
+          }
+          break;
+        }
+
+        case "RAMPS_TRANSACTION_COMPLETE":
+          onSuccessRef.current?.(pendingAmountRef.current);
+          onCloseRef.current();
+          break;
+
+        case "RAMPS_OPEN_URL":
+          if (payload?.url && typeof payload.url === "string") {
+            window.open(payload.url, "_blank", "noopener,noreferrer");
+          }
+          break;
+
+        case "RAMPS_CLOSE":
+          onCloseRef.current();
+          break;
+      }
+    }
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [open]);
+
+  if (!open) return null;
+
+  const src = `${WIDGET_ORIGIN}/stub-widget.html?mode=off-ramp&key=${env.NEXT_PUBLIC_MG_RAMP_KEY}&theme=dark`;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative w-full max-w-md h-[600px] rounded-2xl overflow-hidden shadow-2xl">
+        <iframe
+          ref={iframeRef}
+          src={src}
+          style={{ width: "100%", height: "100%", border: "none" }}
+          allow="clipboard-write; camera"
+          title="Cash Pickup"
+        />
+      </div>
+    </div>
+  );
+}

--- a/examples/moneygram-ramp/components/chain-selector.tsx
+++ b/examples/moneygram-ramp/components/chain-selector.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import clsx from "clsx";
+import { CHAINS, type MgChain } from "@/lib/chains";
+
+const CHAIN_ORDER: MgChain[] = ["base", "ethereum", "solana"];
+
+interface ChainSelectorProps {
+  selected: MgChain;
+  onChange: (chain: MgChain) => void;
+}
+
+export function ChainSelector({ selected, onChange }: ChainSelectorProps) {
+  return (
+    <div className="flex gap-2">
+      {CHAIN_ORDER.map((chain) => (
+        <button
+          key={chain}
+          onClick={() => onChange(chain)}
+          className={clsx(
+            "px-3.5 py-1.5 rounded-lg text-sm font-medium transition-colors",
+            selected === chain
+              ? "bg-teal-600/20 border border-teal-600/40 text-teal-400"
+              : "text-gray-400 hover:text-white hover:bg-gray-800/60 border border-transparent",
+          )}
+        >
+          {CHAINS[chain].name}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/examples/moneygram-ramp/components/header.tsx
+++ b/examples/moneygram-ramp/components/header.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { isSignedIn, logout, onEvent } from "@dynamic-labs-sdk/client";
+import { initDynamic, dynamicClient } from "@/lib/dynamic";
+import { LogOut } from "lucide-react";
+
+export function Header() {
+  const [signedIn, setSignedIn] = useState(false);
+
+  useEffect(() => {
+    let unsub: (() => void) | undefined;
+    initDynamic().then(() => {
+      setSignedIn(isSignedIn());
+      unsub = onEvent(
+        { event: "tokenChanged", listener: ({ token }) => setSignedIn(!!token) },
+        dynamicClient,
+      );
+    });
+    return () => unsub?.();
+  }, []);
+
+  return (
+    <header className="border-b border-gray-800/60 bg-gray-950/80 backdrop-blur-sm sticky top-0 z-50">
+      <div className="container mx-auto px-4 py-3.5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-teal-400 to-teal-600 flex items-center justify-center">
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                <path d="M7 1L13 4V10L7 13L1 10V4L7 1Z" stroke="white" strokeWidth="1.5" strokeLinejoin="round" />
+              </svg>
+            </div>
+            <span className="text-white font-semibold text-base tracking-tight">Cash Pickup</span>
+          </div>
+          {signedIn && (
+            <button
+              onClick={() => logout(dynamicClient)}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-gray-400 hover:text-white hover:bg-gray-800/60 transition-colors"
+            >
+              <LogOut size={14} />
+              Sign out
+            </button>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/examples/moneygram-ramp/components/ramp-app.tsx
+++ b/examples/moneygram-ramp/components/ramp-app.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  isSignedIn,
+  sendEmailOTP,
+  verifyOTP,
+  getWalletAccounts,
+  onEvent,
+  type OTPVerification,
+} from "@dynamic-labs-sdk/client";
+import { createWaasWalletAccounts } from "@dynamic-labs-sdk/client/waas";
+import { initDynamic, dynamicClient } from "@/lib/dynamic";
+import { isEvmWalletAccount } from "@dynamic-labs-sdk/evm";
+import { isSolanaWalletAccount } from "@dynamic-labs-sdk/solana";
+import type { WalletAccount } from "@dynamic-labs-sdk/client";
+import { ArrowRight, Banknote, Check, Copy, Globe, Wallet, Zap } from "lucide-react";
+import { toast } from "sonner";
+import { ChainSelector } from "./chain-selector";
+import { CashPickupWidget } from "./cash-pickup-widget";
+import { CHAINS, type MgChain } from "@/lib/chains";
+import { fetchUsdcBalance } from "@/lib/balance";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function getAddressForChain(chain: MgChain, accounts: WalletAccount[]): string {
+  if (chain === "solana") return accounts.find(isSolanaWalletAccount)?.address ?? "";
+  return accounts.find(isEvmWalletAccount)?.address ?? "";
+}
+
+function truncate(addr: string): string {
+  if (!addr) return "";
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+export function RampApp() {
+  const [signedIn, setSignedIn] = useState(false);
+  const [walletAccounts, setWalletAccounts] = useState<WalletAccount[]>([]);
+  const [selectedChain, setSelectedChain] = useState<MgChain>("base");
+  const [usdcBalance, setUsdcBalance] = useState<number | null>(null);
+  const [widgetOpen, setWidgetOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const [email, setEmail] = useState("");
+  const [otp, setOtp] = useState("");
+  const [otpVerification, setOtpVerification] = useState<OTPVerification | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let unsubToken: (() => void) | undefined;
+    let unsubWallets: (() => void) | undefined;
+    initDynamic().then(async () => {
+      if (isSignedIn()) {
+        const existing = getWalletAccounts();
+        if (existing.length === 0) {
+          await createWaasWalletAccounts({ chains: ["EVM", "SOL"] }, dynamicClient);
+        }
+        setSignedIn(true);
+        setWalletAccounts(getWalletAccounts());
+      }
+      unsubToken = onEvent(
+        { event: "tokenChanged", listener: ({ token }) => {
+          setSignedIn(!!token);
+          if (!token) setWalletAccounts([]);
+        }},
+        dynamicClient,
+      );
+      unsubWallets = onEvent(
+        { event: "walletAccountsChanged", listener: ({ walletAccounts }) => setWalletAccounts(walletAccounts) },
+        dynamicClient,
+      );
+    });
+    return () => {
+      unsubToken?.();
+      unsubWallets?.();
+    };
+  }, []);
+
+  const address = getAddressForChain(selectedChain, walletAccounts);
+
+  useEffect(() => {
+    if (!address) { setUsdcBalance(null); return; }
+    setUsdcBalance(null);
+    fetchUsdcBalance(selectedChain, address).then(setUsdcBalance);
+  }, [selectedChain, address]);
+
+  const handleSendOtp = async () => {
+    if (!email) return;
+    setLoading(true);
+    try {
+      const verification = await sendEmailOTP({ email });
+      setOtpVerification(verification);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to send code");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleVerifyOtp = async () => {
+    if (!otp || !otpVerification) return;
+    setLoading(true);
+    try {
+      await verifyOTP({ otpVerification, verificationToken: otp });
+      if (getWalletAccounts().length === 0) {
+        await createWaasWalletAccounts({ chains: ["EVM", "SOL"] }, dynamicClient);
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Invalid code");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSuccess = useCallback((amount: number) => {
+    toast.success(`${amount > 0 ? `$${amount.toFixed(2)} USDC` : "Funds"} sent for cash pickup on ${CHAINS[selectedChain].name}`);
+    if (address) fetchUsdcBalance(selectedChain, address).then(setUsdcBalance);
+  }, [selectedChain, address]);
+
+  // ── Landing / Auth ──────────────────────────────────────────────────────────
+
+  if (!signedIn) {
+    return (
+      <div className="min-h-screen bg-gray-950 text-white">
+        {/* Hero */}
+        <div className="relative overflow-hidden">
+          <div className="absolute inset-0 bg-linear-to-br from-teal-950/40 via-gray-950 to-gray-950 pointer-events-none" />
+          <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[600px] h-[400px] bg-teal-500/5 rounded-full blur-3xl pointer-events-none" />
+
+          <div className="relative container mx-auto px-4 pt-20 pb-16 text-center">
+            <h1 className="text-5xl sm:text-6xl font-bold mb-5 tracking-tight leading-[1.1]">
+              USDC to cash,{" "}
+              <span className="bg-linear-to-r from-teal-400 to-teal-600 bg-clip-text text-transparent">
+                anywhere
+              </span>
+            </h1>
+            <p className="text-lg text-gray-400 mb-10 max-w-md mx-auto leading-relaxed">
+              Off-ramp your USDC across Base, Ethereum, and Solana. Pick up
+              cash at thousands of locations worldwide.
+            </p>
+
+            {/* Auth card */}
+            <div className="mx-auto max-w-xs bg-gray-900 border border-gray-800 rounded-2xl p-6 text-left space-y-3">
+              {!otpVerification ? (
+                <>
+                  <input
+                    type="email"
+                    placeholder="Email address"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleSendOtp()}
+                    className="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-2.5 text-white placeholder-gray-500 text-sm focus:outline-none focus:border-teal-600 transition-colors"
+                    suppressHydrationWarning
+                  />
+                  <button
+                    onClick={handleSendOtp}
+                    disabled={loading || !email}
+                    className="w-full flex items-center justify-center gap-2 bg-teal-600 hover:bg-teal-500 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl py-2.5 text-sm font-semibold transition-all duration-200 hover:shadow-lg hover:shadow-teal-500/25"
+                  >
+                    {loading ? "Sending..." : "Get started"}
+                    {!loading && <ArrowRight className="w-4 h-4" />}
+                  </button>
+                </>
+              ) : (
+                <>
+                  <p className="text-xs text-gray-500 text-center">
+                    Code sent to <span className="text-gray-300">{email}</span>
+                  </p>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    placeholder="6-digit code"
+                    value={otp}
+                    onChange={(e) => setOtp(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleVerifyOtp()}
+                    className="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-2.5 text-white placeholder-gray-500 text-sm text-center tracking-widest focus:outline-none focus:border-teal-600 transition-colors"
+                    maxLength={6}
+                  />
+                  <button
+                    onClick={handleVerifyOtp}
+                    disabled={loading || otp.length < 6}
+                    className="w-full flex items-center justify-center gap-2 bg-teal-600 hover:bg-teal-500 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl py-2.5 text-sm font-semibold transition-all duration-200"
+                  >
+                    {loading ? "Verifying..." : "Verify"}
+                    {!loading && <ArrowRight className="w-4 h-4" />}
+                  </button>
+                  <button
+                    onClick={() => { setOtpVerification(null); setOtp(""); }}
+                    className="w-full text-gray-500 hover:text-gray-300 text-xs text-center transition-colors py-1"
+                  >
+                    ← Back
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Feature cards */}
+        <div className="container mx-auto px-4 py-16">
+          <div className="grid md:grid-cols-3 gap-5 max-w-3xl mx-auto">
+            {[
+              {
+                icon: Wallet,
+                color: "teal",
+                title: "Embedded wallets",
+                desc: "Non-custodial wallets created automatically — no extensions or seed phrases.",
+              },
+              {
+                icon: Zap,
+                color: "purple",
+                title: "Multi-chain",
+                desc: "Send USDC on Base, Ethereum, or Solana — switch chains anytime.",
+              },
+              {
+                icon: Globe,
+                color: "blue",
+                title: "Global pickup",
+                desc: "Thousands of cash pickup locations across 200+ countries.",
+              },
+            ].map(({ icon: Icon, color, title, desc }) => (
+              <div
+                key={title}
+                className="bg-gray-900 border border-gray-800 rounded-2xl p-6 hover:border-gray-700 transition-colors"
+              >
+                <div
+                  className={`w-10 h-10 rounded-xl flex items-center justify-center mb-4 ${
+                    color === "teal" ? "bg-teal-500/10" : color === "purple" ? "bg-purple-500/10" : "bg-blue-500/10"
+                  }`}
+                >
+                  <Icon
+                    className={`w-5 h-5 ${
+                      color === "teal" ? "text-teal-400" : color === "purple" ? "text-purple-400" : "text-blue-400"
+                    }`}
+                  />
+                </div>
+                <h3 className="font-semibold text-white mb-1.5">{title}</h3>
+                <p className="text-sm text-gray-500 leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+
+          {/* How it works */}
+          <div className="max-w-lg mx-auto mt-20">
+            <h2 className="text-2xl font-bold text-center mb-10">How it works</h2>
+            <div className="relative space-y-0">
+              {[
+                {
+                  step: "01",
+                  title: "Sign in",
+                  desc: "Authenticate with email — an embedded wallet is created automatically.",
+                },
+                {
+                  step: "02",
+                  title: "Choose your chain",
+                  desc: "Select Base, Ethereum, or Solana — whichever holds your USDC.",
+                },
+                {
+                  step: "03",
+                  title: "Pick up cash",
+                  desc: "Enter the amount, complete the flow, and collect cash at a nearby location.",
+                },
+              ].map(({ step, title, desc }, i) => (
+                <div key={step} className="flex gap-5">
+                  <div className="flex flex-col items-center">
+                    <div className="w-9 h-9 rounded-full bg-teal-600/20 border border-teal-600/40 flex items-center justify-center flex-shrink-0">
+                      <span className="text-teal-400 text-xs font-bold">{step}</span>
+                    </div>
+                    {i < 2 && <div className="w-px h-10 bg-gray-800 mt-1" />}
+                  </div>
+                  <div className="pb-10">
+                    <h4 className="font-semibold text-white mb-1">{title}</h4>
+                    <p className="text-sm text-gray-500 leading-relaxed">{desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Ramp UI ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white">
+      <div className="container mx-auto px-4 py-12">
+        <div className="max-w-sm mx-auto space-y-5">
+          <div>
+            <h2 className="text-xl font-bold text-white mb-1">Off-ramp USDC</h2>
+            <p className="text-sm text-gray-500">
+              Select a network and send USDC for cash pickup.
+            </p>
+          </div>
+
+          <ChainSelector selected={selectedChain} onChange={setSelectedChain} />
+
+          {/* Wallet card */}
+          <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 space-y-5 hover:border-gray-700 transition-colors">
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-xl bg-teal-500/10 flex items-center justify-center flex-shrink-0">
+                <Wallet className="w-5 h-5 text-teal-400" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-xs text-gray-500">{CHAINS[selectedChain].name}</p>
+                <p className="text-sm font-mono text-white">
+                  {address ? truncate(address) : <span className="text-gray-600">No wallet</span>}
+                </p>
+              </div>
+              {address && (
+                <button
+                  onClick={() => {
+                    navigator.clipboard.writeText(address);
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 2000);
+                  }}
+                  className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-800 transition-colors"
+                  title="Copy address"
+                >
+                  {copied ? <Check className="w-3.5 h-3.5 text-teal-400" /> : <Copy className="w-3.5 h-3.5" />}
+                </button>
+              )}
+            </div>
+
+            <div className="border-t border-gray-800 pt-4">
+              <p className="text-xs text-gray-500 mb-1">USDC balance</p>
+              <p className="text-3xl font-bold text-white">
+                {usdcBalance === null ? (
+                  <span className="text-gray-700 text-xl font-normal">Loading...</span>
+                ) : (
+                  <>${usdcBalance.toFixed(2)}</>
+                )}
+              </p>
+            </div>
+
+            <button
+              onClick={() => setWidgetOpen(true)}
+              disabled={!address || !usdcBalance}
+              className="w-full flex items-center justify-center gap-2.5 bg-teal-600 hover:bg-teal-500 disabled:opacity-40 disabled:cursor-not-allowed text-white rounded-xl py-3 text-sm font-semibold transition-all duration-200 hover:shadow-lg hover:shadow-teal-500/25"
+            >
+              <Banknote className="w-4 h-4" />
+              Cash Pickup
+            </button>
+          </div>
+
+          <p className="text-center text-xs text-gray-600">
+            USDC on {CHAINS[selectedChain].name} → cash at pickup locations worldwide
+          </p>
+        </div>
+      </div>
+
+      <CashPickupWidget
+        open={widgetOpen}
+        selectedChain={selectedChain}
+        walletAccounts={walletAccounts}
+        onClose={() => setWidgetOpen(false)}
+        onSuccess={handleSuccess}
+      />
+    </div>
+  );
+}

--- a/examples/moneygram-ramp/lib/balance.ts
+++ b/examples/moneygram-ramp/lib/balance.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { createPublicClient, formatUnits, http, parseAbi } from "viem";
+import { Connection, PublicKey } from "@solana/web3.js";
+import { getAssociatedTokenAddress } from "@solana/spl-token";
+import { CHAINS, type MgChain } from "./chains";
+
+const erc20BalanceAbi = parseAbi([
+  "function balanceOf(address) view returns (uint256)",
+]);
+
+/**
+ * Fetch on-chain USDC balance for the given chain and address.
+ * Returns 0 if the account doesn't exist or on any error.
+ */
+export async function fetchUsdcBalance(
+  chain: MgChain,
+  address: string,
+): Promise<number> {
+  if (!address) return 0;
+
+  const config = CHAINS[chain];
+
+  try {
+    if (config.type === "evm") {
+      const client = createPublicClient({
+        chain: config.viemChain,
+        transport: http(),
+      });
+      const raw = await client.readContract({
+        address: config.usdcAddress,
+        abi: erc20BalanceAbi,
+        functionName: "balanceOf",
+        args: [address as `0x${string}`],
+      });
+      return parseFloat(formatUnits(raw, 6));
+    }
+
+    if (config.type === "solana") {
+      const connection = new Connection(config.rpcUrl, "confirmed");
+      const ata = await getAssociatedTokenAddress(
+        new PublicKey(config.usdcMint),
+        new PublicKey(address),
+      );
+      const info = await connection.getTokenAccountBalance(ata);
+      return parseFloat(info.value.uiAmountString ?? "0");
+    }
+  } catch {
+    // Token account may not exist yet (zero balance)
+  }
+
+  return 0;
+}

--- a/examples/moneygram-ramp/lib/chains.ts
+++ b/examples/moneygram-ramp/lib/chains.ts
@@ -1,0 +1,56 @@
+import { baseSepolia, sepolia } from "viem/chains";
+import type { Chain } from "viem";
+import { env } from "./env";
+
+/**
+ * MoneyGram chain identifiers as required by the RAMPS_CONFIG message.
+ * Note: use "base" for Base transactions — NOT "ethereum".
+ */
+export type MgChain = "base" | "ethereum" | "solana";
+
+interface EvmChainConfig {
+  type: "evm";
+  name: string;
+  mgChain: MgChain;
+  networkId: number;
+  viemChain: Chain;
+  usdcAddress: `0x${string}`;
+}
+
+interface SolanaChainConfig {
+  type: "solana";
+  name: string;
+  mgChain: MgChain;
+  rpcUrl: string;
+  usdcMint: string;
+}
+
+export type ChainConfig = EvmChainConfig | SolanaChainConfig;
+
+export const CHAINS: Record<MgChain, ChainConfig> = {
+  base: {
+    type: "evm",
+    name: "Base Sepolia",
+    mgChain: "base",
+    networkId: 84532,
+    viemChain: baseSepolia,
+    // Circle USDC on Base Sepolia
+    usdcAddress: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  },
+  ethereum: {
+    type: "evm",
+    name: "Eth Sepolia",
+    mgChain: "ethereum",
+    networkId: 11155111,
+    viemChain: sepolia,
+    // Circle USDC on Eth Sepolia
+    usdcAddress: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+  },
+  solana: {
+    type: "solana",
+    name: "Solana Devnet",
+    mgChain: "solana",
+    rpcUrl: env.NEXT_PUBLIC_SOLANA_RPC_URL,
+    usdcMint: env.NEXT_PUBLIC_SOLANA_USDC_MINT,
+  },
+};

--- a/examples/moneygram-ramp/lib/dynamic.ts
+++ b/examples/moneygram-ramp/lib/dynamic.ts
@@ -1,0 +1,20 @@
+import { createDynamicClient, initializeClient, type DynamicClient } from "@dynamic-labs-sdk/client";
+import { addWaasEvmExtension } from "@dynamic-labs-sdk/evm/waas";
+import { addWaasSolanaExtension } from "@dynamic-labs-sdk/solana/waas";
+import { env } from "./env";
+
+export const dynamicClient: DynamicClient = createDynamicClient({
+  environmentId: env.NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID,
+  autoInitialize: false,
+  metadata: { name: "MoneyGram Ramp Demo" },
+});
+
+let initialized = false;
+
+export async function initDynamic(): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+  addWaasEvmExtension(dynamicClient);
+  addWaasSolanaExtension(dynamicClient);
+  await initializeClient(dynamicClient);
+}

--- a/examples/moneygram-ramp/lib/env.ts
+++ b/examples/moneygram-ramp/lib/env.ts
@@ -1,0 +1,21 @@
+import { createEnv } from "@t3-oss/env-nextjs";
+import { z } from "zod";
+
+export const env = createEnv({
+  server: {
+    NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+  },
+  client: {
+    NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID: z.string().min(1),
+    NEXT_PUBLIC_MG_RAMP_KEY: z.string().min(1),
+    NEXT_PUBLIC_SOLANA_RPC_URL: z.string().url(),
+    NEXT_PUBLIC_SOLANA_USDC_MINT: z.string().min(1),
+  },
+  runtimeEnv: {
+    NODE_ENV: process.env.NODE_ENV,
+    NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID: process.env.NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID,
+    NEXT_PUBLIC_MG_RAMP_KEY: process.env.NEXT_PUBLIC_MG_RAMP_KEY,
+    NEXT_PUBLIC_SOLANA_RPC_URL: process.env.NEXT_PUBLIC_SOLANA_RPC_URL,
+    NEXT_PUBLIC_SOLANA_USDC_MINT: process.env.NEXT_PUBLIC_SOLANA_USDC_MINT,
+  },
+});

--- a/examples/moneygram-ramp/lib/send-usdc.ts
+++ b/examples/moneygram-ramp/lib/send-usdc.ts
@@ -1,0 +1,120 @@
+"use client";
+
+import { encodeFunctionData, erc20Abi, parseUnits } from "viem";
+import { createWalletClientForWalletAccount } from "@dynamic-labs-sdk/evm/viem";
+import { isEvmWalletAccount } from "@dynamic-labs-sdk/evm";
+import {
+  isSolanaWalletAccount,
+  signAndSendTransaction,
+} from "@dynamic-labs-sdk/solana";
+import {
+  Connection,
+  PublicKey,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import {
+  createAssociatedTokenAccountInstruction,
+  createTransferCheckedInstruction,
+  getAssociatedTokenAddress,
+} from "@solana/spl-token";
+import type { WalletAccount } from "@dynamic-labs-sdk/client";
+import { CHAINS, type MgChain } from "./chains";
+
+/**
+ * Send USDC to the given address on the specified chain.
+ * Dispatches to EVM or Solana signing based on chain type.
+ *
+ * @returns Transaction hash (EVM) or signature (Solana)
+ */
+export async function sendUsdc({
+  to,
+  amount,
+  chain,
+  walletAccounts,
+}: {
+  to: string;
+  amount: string;
+  chain: MgChain;
+  walletAccounts: WalletAccount[];
+}): Promise<string> {
+  const config = CHAINS[chain];
+
+  // ── EVM (Base Sepolia or Eth Sepolia) ──────────────────────────────────────
+  if (config.type === "evm") {
+    const evmWallet = walletAccounts.find(isEvmWalletAccount);
+    if (!evmWallet) throw new Error("No EVM wallet found. Connect an EVM embedded wallet.");
+
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "transfer",
+      args: [to as `0x${string}`, parseUnits(amount, 6)],
+    });
+
+    const walletClient = await createWalletClientForWalletAccount({
+      walletAccount: evmWallet,
+    });
+
+    return walletClient.sendTransaction({
+      to: config.usdcAddress,
+      data,
+      value: BigInt(0),
+      chain: config.viemChain,
+    });
+  }
+
+  // ── Solana Devnet ──────────────────────────────────────────────────────────
+  const solanaWallet = walletAccounts.find(isSolanaWalletAccount);
+  if (!solanaWallet) throw new Error("No Solana wallet found. Connect a Solana embedded wallet.");
+
+  const connection = new Connection(config.rpcUrl, "confirmed");
+  const fromPubkey = new PublicKey(solanaWallet.address);
+  const toPubkey = new PublicKey(to);
+  const mintPubkey = new PublicKey(config.usdcMint);
+
+  const senderATA = await getAssociatedTokenAddress(mintPubkey, fromPubkey);
+  const recipientATA = await getAssociatedTokenAddress(mintPubkey, toPubkey);
+  const tokenAmount = BigInt(Math.floor(parseFloat(amount) * 1_000_000));
+
+  const instructions = [];
+
+  const recipientInfo = await connection.getAccountInfo(recipientATA);
+  if (!recipientInfo) {
+    instructions.push(
+      createAssociatedTokenAccountInstruction(
+        fromPubkey,
+        recipientATA,
+        toPubkey,
+        mintPubkey,
+      ),
+    );
+  }
+
+  instructions.push(
+    createTransferCheckedInstruction(
+      senderATA,
+      mintPubkey,
+      recipientATA,
+      fromPubkey,
+      tokenAmount,
+      6,
+    ),
+  );
+
+  const { blockhash } = await connection.getLatestBlockhash("finalized");
+  const message = new TransactionMessage({
+    payerKey: fromPubkey,
+    recentBlockhash: blockhash,
+    instructions,
+  }).compileToV0Message();
+
+  const tx = new VersionedTransaction(message);
+  // Type assertion handles potential @solana/web3.js version mismatches
+  const txPayload = {
+    transaction: tx as unknown as Parameters<typeof signAndSendTransaction>[0]["transaction"],
+    walletAccount: solanaWallet,
+  };
+
+  const { signature } = await signAndSendTransaction(txPayload);
+  return signature;
+}

--- a/examples/moneygram-ramp/next-env.d.ts
+++ b/examples/moneygram-ramp/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/moneygram-ramp/next.config.ts
+++ b/examples/moneygram-ramp/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/examples/moneygram-ramp/package.json
+++ b/examples/moneygram-ramp/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@dynamic-demos/moneygram-ramp",
+  "version": "0.1.0",
+  "description": "MoneyGram Ramps off-ramp demo with Dynamic embedded wallets across Base, Ethereum, and Solana",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@dynamic-labs-sdk/client": "0.12.1",
+    "@dynamic-labs-sdk/evm": "0.12.1",
+    "@dynamic-labs-sdk/solana": "0.12.1",
+    "@solana/spl-token": "0.4.13",
+    "@solana/web3.js": "1.98.4",
+    "@t3-oss/env-nextjs": "0.13.8",
+    "clsx": "2.1.1",
+    "lucide-react": "0.542.0",
+    "next": "15.5.9",
+    "react": "19.1.4",
+    "react-dom": "19.1.4",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "3.4.0",
+    "viem": "2.42.1",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "3.3.1",
+    "@tailwindcss/postcss": "4.1.17",
+    "@types/node": "20.19.25",
+    "@types/react": "19.2.5",
+    "@types/react-dom": "19.2.3",
+    "eslint": "9.39.1",
+    "eslint-config-next": "15.5.4",
+    "tailwindcss": "4.1.17",
+    "typescript": "5.9.3"
+  }
+}

--- a/examples/moneygram-ramp/postcss.config.mjs
+++ b/examples/moneygram-ramp/postcss.config.mjs
@@ -1,0 +1,2 @@
+const config = { plugins: ["@tailwindcss/postcss"] };
+export default config;

--- a/examples/moneygram-ramp/tsconfig.json
+++ b/examples/moneygram-ramp/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noUncheckedIndexedAccess": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- New example demonstrating USDC-to-cash off-ramp via MoneyGram RAMPS with Dynamic embedded wallets
- Multi-chain support: Base Sepolia, Eth Sepolia, and Solana Devnet
- Email OTP authentication with auto-created embedded wallets (no seed phrases)

## Fixes applied during review
- Fix runtime crash: undefined `setOtpSent` → `setOtpVerification(null)` on Back button
- Move hardcoded Helius RPC URL and USDC mint to env vars (`NEXT_PUBLIC_SOLANA_RPC_URL`, `NEXT_PUBLIC_SOLANA_USDC_MINT`)
- Use validated `env` in `dynamic.ts` instead of raw `process.env!`
- Remove unused `Shield` icon import
- Use `clsx` instead of `.join(" ")` for conditional class names in `ChainSelector`

## Test plan
- [ ] Copy `.env.example` to `.env` and fill in values
- [ ] `bun dev` — verify sign-in with email OTP creates embedded wallets
- [ ] Switch chains — confirm address and balance update per chain
- [ ] Click Cash Pickup — confirm MoneyGram iframe loads and postMessage flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)