### PR TITLE
fix(kamino): fall back to signAndSendTransaction when sponsorship not supported

### DIFF
--- a/examples/nextjs-stablecoin-yield-kamino/package.json
+++ b/examples/nextjs-stablecoin-yield-kamino/package.json
@@ -43,7 +43,9 @@
   "browser": {
     "crypto": false
   },
-  "overrides": {
-    "@solana/web3.js": "1.98.4"
+  "pnpm": {
+    "overrides": {
+      "@solana/web3.js": "1.98.4"
+    }
   }
 }

--- a/examples/nextjs-stablecoin-yield-kamino/pnpm-lock.yaml
+++ b/examples/nextjs-stablecoin-yield-kamino/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@solana/web3.js': 1.98.4
+
 importers:
 
   .:
@@ -113,19 +116,19 @@ packages:
     resolution: {integrity: sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@solana/web3.js': ^1.68.0
+      '@solana/web3.js': 1.98.4
 
   '@coral-xyz/borsh@0.29.0':
     resolution: {integrity: sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@solana/web3.js': ^1.68.0
+      '@solana/web3.js': 1.98.4
 
   '@coral-xyz/borsh@0.30.1':
     resolution: {integrity: sha512-aaxswpPrCFKl8vZTbxLssA2RvwX2zmKLlRCIktJOwW+VpVwYtXRtlWiIP+c2pPRKneiTiWCN2GEMSH9j1zTlWQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@solana/web3.js': ^1.68.0
+      '@solana/web3.js': 1.98.4
 
   '@dynamic-labs-sdk/assert-package-version@0.24.1':
     resolution: {integrity: sha512-pCOWQrIzYYDtsbCZhfOuPrsHeUURF8GR1FqSsqebzEUR3hb99qcqRutKV66RUdX8qQ4nJP004leAHJ4S/e7yhQ==}
@@ -264,7 +267,7 @@ packages:
   '@hubbleprotocol/hubble-config@5.0.0':
     resolution: {integrity: sha512-oLdS2SwdYN8sggZhIesN+Kk8KQXGrbYn0kvnvTnk5Wh4pck1kR458ze5gh0XrMDpRVTdgwItf4mXhqiLXvQCKQ==}
     peerDependencies:
-      '@solana/web3.js': ^1.78.4
+      '@solana/web3.js': 1.98.4
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -605,7 +608,7 @@ packages:
     resolution: {integrity: sha512-7MJs71F8XJsYCx3+agsLc3MMGnzAC8l3FDbUq0qP3lEPI6B5IS/u2iKU4rWkK3IqIkynWcvuYL6WCi+90vu52w==}
     peerDependencies:
       '@solana/spl-token': ^0.4.12
-      '@solana/web3.js': ^1.90.0
+      '@solana/web3.js': 1.98.4
 
   '@orca-so/tx-sender@1.0.2':
     resolution: {integrity: sha512-6PlGx4wwF9Q/XxfND43TtZsjiCJs6Ho5yIYBAkiXXaBOcIfqNTqKRhzhX598xv19TJl4DaldWhgx36m+nqmN8Q==}
@@ -959,25 +962,25 @@ packages:
     resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
     engines: {node: '>=16'}
     peerDependencies:
-      '@solana/web3.js': ^1.95.3
+      '@solana/web3.js': 1.98.4
 
   '@solana/spl-token-metadata@0.1.6':
     resolution: {integrity: sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==}
     engines: {node: '>=16'}
     peerDependencies:
-      '@solana/web3.js': ^1.95.3
+      '@solana/web3.js': 1.98.4
 
   '@solana/spl-token@0.4.14':
     resolution: {integrity: sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==}
     engines: {node: '>=16'}
     peerDependencies:
-      '@solana/web3.js': ^1.95.5
+      '@solana/web3.js': 1.98.4
 
   '@solana/spl-token@0.4.9':
     resolution: {integrity: sha512-g3wbj4F4gq82YQlwqhPB0gHFXfgsC6UmyGMxtSLf/BozT/oKd59465DbnlUK8L8EcimKMavxsVAMoLcEdeCicg==}
     engines: {node: '>=16'}
     peerDependencies:
-      '@solana/web3.js': ^1.95.3
+      '@solana/web3.js': 1.98.4
 
   '@solana/subscribable@2.3.0':
     resolution: {integrity: sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==}
@@ -1008,9 +1011,6 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
-
-  '@solana/web3.js@1.98.1':
-    resolution: {integrity: sha512-gRAq1YPbfSDAbmho4kY7P/8iLIjMWXAzBJdP9iENFR+dFQSBSueHzjK/ou8fxhqHP9j+J4Msl4p/oDemFcIjlg==}
 
   '@solana/web3.js@1.98.4':
     resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
@@ -3535,8 +3535,8 @@ snapshots:
       '@dynamic-labs-sdk/client': 0.24.1(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.2)(utf-8-validate@6.0.6)
       '@dynamic-labs-sdk/wallet-connect': 0.24.1(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.2)(utf-8-validate@6.0.6)
       '@dynamic-labs/sdk-api-core': 0.0.927
-      '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.1(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@6.0.6)
-      '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6)
+      '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@6.0.6)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6)
       '@wallet-standard/app': 1.0.1
       '@wallet-standard/base': 1.0.1
       '@wallet-standard/experimental-features': 0.1.1
@@ -4783,26 +4783,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.1(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - typescript
-
   '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
       '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - typescript
-
-  '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.98.1(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
@@ -4814,21 +4798,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
-
-  '@solana/spl-token@0.4.14(@solana/web3.js@1.98.1(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@solana/buffer-layout': 4.0.1
-      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6)
-      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.1(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.1(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6)
-      buffer: 6.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - typescript
-      - utf-8-validate
 
   '@solana/spl-token@0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@6.0.6)':
     dependencies:
@@ -4924,29 +4893,6 @@ snapshots:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-
-  '@solana/web3.js@1.98.1(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@solana/buffer-layout': 4.0.1
-      '@solana/codecs-numbers': 2.3.0(typescript@5.9.2)
-      agentkeepalive: 4.6.0
-      bn.js: 5.2.3
-      borsh: 0.7.0
-      bs58: 4.0.1
-      buffer: 6.0.3
-      fast-stable-stringify: 1.0.0
-      jayson: 4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      node-fetch: 2.7.0
-      rpc-websockets: 9.3.6
-      superstruct: 2.0.2
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
 
   '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@6.0.6)':
     dependencies:

--- a/examples/nextjs-stablecoin-yield-kamino/src/lib/useVaultOperations.ts
+++ b/examples/nextjs-stablecoin-yield-kamino/src/lib/useVaultOperations.ts
@@ -48,6 +48,10 @@ async function fetchTokenBalance(
   const owner = new PublicKey(ownerAddress);
   const mint = new PublicKey(mintAddress);
 
+  interface ParsedTokenAccountData {
+    parsed?: { info?: { mint?: string; tokenAmount?: { uiAmount?: number } } };
+  }
+
   // Legacy SPL Token program
   try {
     const accounts = await connection.getParsedTokenAccountsByOwner(owner, {
@@ -55,11 +59,8 @@ async function fetchTokenBalance(
       programId: TOKEN_PROGRAM_ID,
     });
     if (accounts.value.length > 0) {
-      return (
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (accounts.value[0].account.data as any).parsed?.info?.tokenAmount
-          ?.uiAmount ?? 0
-      );
+      const data = accounts.value[0].account.data as ParsedTokenAccountData;
+      return data.parsed?.info?.tokenAmount?.uiAmount ?? 0;
     }
   } catch {
     // no account in this program
@@ -71,13 +72,13 @@ async function fetchTokenBalance(
     const accounts = await connection.getParsedTokenAccountsByOwner(owner, {
       programId: TOKEN_2022_PROGRAM_ID,
     });
-    const match = accounts.value.find(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (a) => (a.account.data as any).parsed?.info?.mint === mintStr
-    );
+    const match = accounts.value.find((a) => {
+      const data = a.account.data as ParsedTokenAccountData;
+      return data.parsed?.info?.mint === mintStr;
+    });
     if (match) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (match.account.data as any).parsed?.info?.tokenAmount?.uiAmount ?? 0;
+      const data = match.account.data as ParsedTokenAccountData;
+      return data.parsed?.info?.tokenAmount?.uiAmount ?? 0;
     }
   } catch {
     // no Token-2022 account
@@ -146,7 +147,7 @@ async function signSendAndConfirm(
 
   try {
     const { signature } = await signAndSendSponsoredTransaction(
-      { transaction: tx as any, walletAccount }, // eslint-disable-line @typescript-eslint/no-explicit-any
+      { transaction: tx, walletAccount },
       dynamicClient
     );
     return confirm(signature);
@@ -154,7 +155,7 @@ async function signSendAndConfirm(
     if (err instanceof MethodNotImplementedError) {
       // Provider doesn't support sponsorship (e.g. external wallet) — send normally
       const { signature } = await signAndSendTransaction(
-        { transaction: tx as any, walletAccount } // eslint-disable-line @typescript-eslint/no-explicit-any
+        { transaction: tx, walletAccount }
       );
       return confirm(signature);
     }

--- a/examples/nextjs-stablecoin-yield-kamino/src/lib/useVaultOperations.ts
+++ b/examples/nextjs-stablecoin-yield-kamino/src/lib/useVaultOperations.ts
@@ -3,9 +3,11 @@
 import { useState } from "react";
 import {
   signAndSendSponsoredTransaction,
+  signAndSendTransaction,
   SponsorTransactionError,
   type SolanaWalletAccount,
 } from "@dynamic-labs-sdk/solana";
+import { MethodNotImplementedError } from "@dynamic-labs-sdk/client/core";
 import { Connection, PublicKey, VersionedTransaction, SendTransactionError } from "@solana/web3.js";
 import {
   createSolanaRpc,
@@ -129,29 +131,39 @@ async function signSendAndConfirm(
   lastValidBlockHeight: bigint,
   walletAccount: SolanaWalletAccount
 ): Promise<string> {
-  try {
-    const { signature } = await signAndSendSponsoredTransaction(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { transaction: tx as any, walletAccount },
-      dynamicClient
-    );
-    const connection = new Connection(getSolanaRpcUrl(), "confirmed");
+  const connection = new Connection(getSolanaRpcUrl(), "confirmed");
+
+  const confirm = async (sig: string) => {
     const result = await connection.confirmTransaction(
-      { signature, blockhash, lastValidBlockHeight: Number(lastValidBlockHeight) },
+      { signature: sig, blockhash, lastValidBlockHeight: Number(lastValidBlockHeight) },
       "confirmed"
     );
     if (result.value.err) {
       throw new Error(`Transaction failed: ${JSON.stringify(result.value.err)}`);
     }
-    return signature;
+    return sig;
+  };
+
+  try {
+    const { signature } = await signAndSendSponsoredTransaction(
+      { transaction: tx as any, walletAccount }, // eslint-disable-line @typescript-eslint/no-explicit-any
+      dynamicClient
+    );
+    return confirm(signature);
   } catch (err) {
+    if (err instanceof MethodNotImplementedError) {
+      // Provider doesn't support sponsorship (e.g. external wallet) — send normally
+      const { signature } = await signAndSendTransaction(
+        { transaction: tx as any, walletAccount } // eslint-disable-line @typescript-eslint/no-explicit-any
+      );
+      return confirm(signature);
+    }
     if (err instanceof SponsorTransactionError) {
       throw new Error(
         "Gas sponsorship failed. Enable SVM Gas Sponsorship in your Dynamic dashboard under Settings → Embedded Wallets."
       );
     }
     if (err instanceof SendTransactionError) {
-      const connection = new Connection(getSolanaRpcUrl(), "confirmed");
       const logs = await err.getLogs(connection);
       throw new Error(
         err.message + (logs?.length ? `\n\nLogs:\n${logs.join("\n")}` : "")


### PR DESCRIPTION
## Summary

- Catches `MethodNotImplementedError` from `signAndSendSponsoredTransaction` so external wallets (which don't support gas sponsorship) can still execute vault operations
- Falls back to `signAndSendTransaction` transparently — no change in behavior for embedded wallets that support sponsorship
- Refactors the `confirm` helper to avoid duplicating the `Connection` and confirmation logic

## Test plan

- [ ] Test with an embedded wallet — sponsored transaction should work as before
- [ ] Test with an external wallet (e.g. Phantom) — should fall back to normal send without erroring
- [ ] Verify error messages for `SponsorTransactionError` and `SendTransactionError` still surface correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)