### PR TITLE
chore: add missing config files across examples

### DIFF
--- a/examples/nextjs-delegated-access/.gitignore
+++ b/examples/nextjs-delegated-access/.gitignore
@@ -1,0 +1,35 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# env files
+.env*
+!.env.example
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/nextjs-external-jwt-stytch/.env.example
+++ b/examples/nextjs-external-jwt-stytch/.env.example
@@ -1,0 +1,10 @@
+# Dynamic environment ID — find this in your Dynamic dashboard under Developer Settings
+NEXT_PUBLIC_DYNAMIC_ENV_ID=your-environment-id-here
+
+# Stytch public token — find in your Stytch dashboard under API Keys
+NEXT_PUBLIC_STYTCH_PUBLIC_TOKEN=your-stytch-public-token
+
+# Stytch server-side credentials — find in your Stytch dashboard under API Keys
+STYTCH_PROJECT_ENV=test
+STYTCH_PROJECT_ID=your-stytch-project-id
+STYTCH_SECRET=your-stytch-secret

--- a/examples/nextjs-external-jwt-stytch/next.config.ts
+++ b/examples/nextjs-external-jwt-stytch/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/examples/nextjs-external-wallets/.gitignore
+++ b/examples/nextjs-external-wallets/.gitignore
@@ -1,0 +1,35 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# env files
+.env*
+!.env.example
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/nextjs-gasless-relayer/eslint.config.mjs
+++ b/examples/nextjs-gasless-relayer/eslint.config.mjs
@@ -1,0 +1,11 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+const eslintConfig = [...compat.extends("next/core-web-vitals", "next/typescript")];
+export default eslintConfig;

--- a/examples/nextjs-gateway-arc/postcss.config.mjs
+++ b/examples/nextjs-gateway-arc/postcss.config.mjs
@@ -1,0 +1,2 @@
+import tailwindcss from "@tailwindcss/postcss";
+export default { plugins: [tailwindcss] };

--- a/examples/nextjs-global-payments-blindpay/postcss.config.mjs
+++ b/examples/nextjs-global-payments-blindpay/postcss.config.mjs
@@ -1,0 +1,2 @@
+import tailwindcss from "@tailwindcss/postcss";
+export default { plugins: [tailwindcss] };

--- a/examples/nextjs-iron-ramp/README.md
+++ b/examples/nextjs-iron-ramp/README.md
@@ -1,0 +1,48 @@
+# Euro Fiat On/Off-Ramp (Iron Finance)
+
+Demonstrates Euro fiat on/off-ramp using Iron Finance and Dynamic embedded wallets.
+
+## Overview
+
+This example shows how to integrate Iron Finance's fiat on/off-ramp into a Next.js app with Dynamic embedded wallets. Users can connect their wallet via Dynamic, then deposit or withdraw EUR using Iron Finance's ramp API. The app supports both sandbox and production environments.
+
+## Setup
+
+### Prerequisites
+- Node.js 18+
+- A [Dynamic](https://app.dynamic.xyz) account with an environment set up
+- An [Iron Finance](https://docs.iron.xyz) account with API credentials
+
+### Environment variables
+
+Copy `.env.example` to `.env.local` and fill in your values:
+
+```bash
+cp .env.example .env.local
+```
+
+| Variable | Description |
+|---|---|
+| `NEXT_PUBLIC_DYNAMIC_ENV_ID` | Your Dynamic environment ID (found in Dashboard → Developer Settings) |
+| `IRON_API_KEY` | Your Iron Finance API key |
+| `IRON_ENVIRONMENT` | Set to `sandbox` for testing or `production` for live |
+| `NEXT_PUBLIC_IRON_ENVIRONMENT` | Client-side environment indicator (`sandbox` or `production`) |
+
+### Install and run
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+## How it works
+
+The app uses Dynamic's JS SDK for wallet authentication and Iron Finance's API for fiat ramp operations. After connecting their wallet, users can initiate EUR deposits or withdrawals which are processed through Iron Finance's payment rails.
+
+## Learn more
+
+- [Dynamic documentation](https://docs.dynamic.xyz)
+- [Iron Finance documentation](https://docs.iron.xyz)
+- [GitHub repository](https://github.com/dynamic-labs-oss/examples)

--- a/examples/nextjs-js-sdk-wallet-demo/eslint.config.mjs
+++ b/examples/nextjs-js-sdk-wallet-demo/eslint.config.mjs
@@ -1,0 +1,11 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+const eslintConfig = [...compat.extends("next/core-web-vitals", "next/typescript")];
+export default eslintConfig;

--- a/examples/nextjs-moneygram-ramp/.gitignore
+++ b/examples/nextjs-moneygram-ramp/.gitignore
@@ -1,0 +1,35 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# env files
+.env*
+!.env.example
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/nextjs-moneygram-ramp/README.md
+++ b/examples/nextjs-moneygram-ramp/README.md
@@ -1,0 +1,48 @@
+# MoneyGram Cash Off-Ramp
+
+Demonstrates MoneyGram cash off-ramp using Dynamic embedded wallets across Base, Ethereum, and Solana.
+
+## Overview
+
+This example shows how to integrate MoneyGram's Ramps API with Dynamic embedded wallets for cash off-ramp functionality. Users can connect their wallet (EVM or Solana) via Dynamic, then initiate USDC withdrawals to cash through the MoneyGram network. The demo supports devnet/sandbox environments.
+
+## Setup
+
+### Prerequisites
+- Node.js 18+
+- A [Dynamic](https://app.dynamic.xyz) account with EVM + Solana embedded wallets enabled
+- A MoneyGram Ramps API key (sandbox prefix: `ramps_pk_sbox_`)
+
+### Environment variables
+
+Copy `.env.example` to `.env.local` and fill in your values:
+
+```bash
+cp .env.example .env.local
+```
+
+| Variable | Description |
+|---|---|
+| `NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID` | Your Dynamic environment ID (found in Dashboard → Developer Settings) |
+| `NEXT_PUBLIC_MG_RAMP_KEY` | Your MoneyGram Ramps API key |
+| `NEXT_PUBLIC_SOLANA_RPC_URL` | Solana RPC endpoint (e.g. Helius, QuickNode, or public devnet) |
+| `NEXT_PUBLIC_SOLANA_USDC_MINT` | USDC SPL token mint address for your environment |
+
+### Install and run
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+## How it works
+
+The app uses Dynamic's JS SDK for multi-chain wallet authentication (EVM and Solana). After connecting, users can initiate USDC off-ramp transactions which are processed through MoneyGram's cash disbursement network.
+
+## Learn more
+
+- [Dynamic documentation](https://docs.dynamic.xyz)
+- [MoneyGram Ramps documentation](https://docs.moneygram.com)
+- [GitHub repository](https://github.com/dynamic-labs-oss/examples)

--- a/examples/nextjs-stablecoin-card-rain/.env.example
+++ b/examples/nextjs-stablecoin-card-rain/.env.example
@@ -1,0 +1,9 @@
+# Dynamic environment ID — find this in your Dynamic dashboard under Developer Settings
+NEXT_PUBLIC_DYNAMIC_ENV_ID=your-environment-id-here
+
+# Dynamic API key — find in your Dynamic dashboard under Developer Settings
+DYNAMIC_API_KEY=your-dynamic-api-key
+
+# Rain card API credentials — find in your Rain dashboard
+RAIN_API_BASE_URL=https://api.rain.com
+RAIN_API_KEY=your-rain-api-key

--- a/examples/nextjs-stablecoin-card-rain/.gitignore
+++ b/examples/nextjs-stablecoin-card-rain/.gitignore
@@ -1,0 +1,35 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# env files
+.env*
+!.env.example
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts


### PR DESCRIPTION
## Summary

Adds standard config files that were present locally but not tracked in git across 10 examples:

- `.gitignore` — nextjs-delegated-access, nextjs-external-wallets, nextjs-moneygram-ramp, nextjs-stablecoin-card-rain
- `.env.example` — nextjs-external-jwt-stytch, nextjs-stablecoin-card-rain
- `next.config.ts` — nextjs-external-jwt-stytch
- `eslint.config.mjs` — nextjs-gasless-relayer, nextjs-js-sdk-wallet-demo
- `postcss.config.mjs` — nextjs-gateway-arc, nextjs-global-payments-blindpay
- `README.md` — nextjs-iron-ramp, nextjs-moneygram-ramp

🤖 Generated with [Claude Code](https://claude.com/claude-code)