### PR TITLE
feat(iron-ramp): add Solana wallet support

### DIFF
--- a/examples/nextjs-iron-ramp/package.json
+++ b/examples/nextjs-iron-ramp/package.json
@@ -12,7 +12,9 @@
   },
   "dependencies": {
     "@dynamic-labs/ethereum": "4.52.2",
+    "@dynamic-labs/ethereum-aa": "^4.83.1",
     "@dynamic-labs/sdk-react-core": "4.52.2",
+    "@dynamic-labs/solana": "4.52.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "2.1.7",
     "@radix-ui/react-select": "2.2.6",

--- a/examples/nextjs-iron-ramp/package.json
+++ b/examples/nextjs-iron-ramp/package.json
@@ -11,9 +11,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@dynamic-labs/ethereum": "4.52.2",
-    "@dynamic-labs/sdk-react-core": "4.52.2",
-    "@dynamic-labs/solana": "4.52.2",
+    "@dynamic-labs/ethereum": "4.83.1",
+    "@dynamic-labs/sdk-react-core": "4.83.1",
+    "@dynamic-labs/solana": "4.83.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "2.1.7",
     "@radix-ui/react-select": "2.2.6",

--- a/examples/nextjs-iron-ramp/package.json
+++ b/examples/nextjs-iron-ramp/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@dynamic-labs/ethereum": "4.52.2",
-    "@dynamic-labs/ethereum-aa": "^4.83.1",
     "@dynamic-labs/sdk-react-core": "4.52.2",
     "@dynamic-labs/solana": "4.52.2",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/examples/nextjs-iron-ramp/pnpm-lock.yaml
+++ b/examples/nextjs-iron-ramp/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
       '@dynamic-labs/ethereum':
         specifier: 4.52.2
         version: 4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
+      '@dynamic-labs/ethereum-aa':
+        specifier: ^4.83.1
+        version: 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(@zerodev/webauthn-key@5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
       '@dynamic-labs/sdk-react-core':
         specifier: 4.52.2
         version: 4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs/solana':
+        specifier: 4.52.2
+        version: 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
@@ -101,6 +107,9 @@ packages:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.0.0
 
+  '@ably/msgpack-js@0.4.1':
+    resolution: {integrity: sha512-Sjxj6SOr17hExAVrsycN7u6oV4PhZcK7Z2S8dM71CH/butgO47cSo/TL6FJPCXUyDAzKkOWjMUpJGyZkEpyu4Q==}
+
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
@@ -128,14 +137,26 @@ packages:
   '@dynamic-labs-sdk/assert-package-version@0.1.2':
     resolution: {integrity: sha512-riWzoNe0NoS0nSWX3pqQ0Tjt3OAIufI0LpuVR0SQwGA1Xr8BsZZs+RKb+cxDMtpyKE+ZaA+U3GEN+UXr2FYm/A==}
 
+  '@dynamic-labs-sdk/assert-package-version@0.26.9':
+    resolution: {integrity: sha512-hB9VvQOhE9j2EHAQfv7LCoLH8+DQXzYveHbsEK5dlU3BB4FoZTdJEU2SEH34q+g7Hyz3Nb+ioc5//jrr/tb39w==}
+
   '@dynamic-labs-sdk/client@0.1.2':
     resolution: {integrity: sha512-2GYWnVGwtD1xfpQunUvmISDlrsAnY7e9rjvebvuAtMy9st9PhZxomLxd0kj9v2sX4R+mxtD0vKuXMS0+p+tJ/Q==}
+
+  '@dynamic-labs-sdk/client@0.26.9':
+    resolution: {integrity: sha512-ubdqCkyiER9Ruc63E4IomvsOMMzSjGbFNeGnn3hIipzamPslrlAO9YTcU50qJEFioMneA2iJ00kbSBx+1VWHmw==}
 
   '@dynamic-labs-wallet/browser-wallet-client@0.0.211':
     resolution: {integrity: sha512-ZYtpKlisiDejEiD2oFIpcpkjFM0UMLTuRZ0gzEe+ybBn4e3g+Yt0XjKdcAPHvQVeIb94TgtZqLmxRW/lQz9hSQ==}
 
   '@dynamic-labs-wallet/browser-wallet-client@0.0.217':
     resolution: {integrity: sha512-t9N1Ml94emoi4o2SxdMzBodlNCOaTsuedIGR2p3ABoF5GddErp3DocNoE5rgOC+U8GdAz9s0N/u9WMRkwHn2Xw==}
+
+  '@dynamic-labs-wallet/browser-wallet-client@0.0.325':
+    resolution: {integrity: sha512-niU6U2OPNg0aPMpQ+yqoTFYayKoRpLSxQg56mKHWM9RmbilGH5jHWXH3mEAVGS7u5YEAuZDnnCavBdWYSBsK5Q==}
+
+  '@dynamic-labs-wallet/browser-wallet-client@0.0.337':
+    resolution: {integrity: sha512-0fZyXUfiZf/mPvvWl+kI4NqUAddWT18dWPRoM08xDUMZ8wGJmyWgD0MeqyJjHV92CV2by2cV+TRcEK3gnaf1sQ==}
 
   '@dynamic-labs-wallet/browser@0.0.167':
     resolution: {integrity: sha512-HDmUetnJ1iz6kGd5PB1kJzeLI7ZJmwxlJ1QGtUqSQHDdBkhLwaDPlccB2IviC5iPfU5PR/IQ1BYEqpoTWx2sBA==}
@@ -149,11 +170,34 @@ packages:
   '@dynamic-labs-wallet/core@0.0.217':
     resolution: {integrity: sha512-TzIyCYlcwFTOTHpr4phU7xQmkY+f76OTiPM/LZ9gW9m0Ji1ETokHfhv6nuLOQSbctGviTdrGxWF1Y1uhaLJEDQ==}
 
+  '@dynamic-labs-wallet/core@0.0.325':
+    resolution: {integrity: sha512-kWlCPMjHVBwiKyWUYrQrsgfTL2Mszsk1acjxJqfsWJucfgOxp432uO5XHGivosu3T1hfGNBNyKK6bChy3gL9Nw==}
+    peerDependencies:
+      '@dynamic-labs-wallet/forward-mpc-client': 0.5.5
+
+  '@dynamic-labs-wallet/core@0.0.337':
+    resolution: {integrity: sha512-csS/Xqx9kERTYLzt7BXHkaIBX8WIfUIDC3R0Yv6fweWdRL+6KX0A6lRUN1lajAF9/7d6XhxVzS/C3umS0qd7JQ==}
+    peerDependencies:
+      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0
+
   '@dynamic-labs-wallet/forward-mpc-client@0.1.3':
     resolution: {integrity: sha512-riZesfU41fMvetaxJ3bO48/9P8ikRPgoVJgWh8m8i0oRyYN7uUz+Iesp+52U12DCtcvSTXljxrKtrV3yqNAYRw==}
 
+  '@dynamic-labs-wallet/forward-mpc-client@0.9.0':
+    resolution: {integrity: sha512-gotV/RnPTJmjosddbZU6L9Rgs6WEJRwNX/VO7v+0JKyyuzIZPvjA2wJLto9EVEiNMCKMES2a+VY39rEqcGNHCg==}
+    peerDependencies:
+      '@dynamic-labs-wallet/primitives': '>=0.0.336 || 0.0.1'
+
   '@dynamic-labs-wallet/forward-mpc-shared@0.1.0':
     resolution: {integrity: sha512-xRpMri4+ZuClonwf04RcnT/BCG8oA36ononD7s0MA5wSqd8kOuHjzNTSoM6lWnPiCmlpECyPARJ1CEO02Sfq9Q==}
+
+  '@dynamic-labs-wallet/forward-mpc-shared@0.7.0':
+    resolution: {integrity: sha512-mN6zT5J8JbZxkOJxEjgGrjURybVn/t9DD+pWW5U4DRZH6Qakn5n1LIB4Lg4Y7OW9WwrlMH2IJ9RNgBW35RaF1A==}
+    peerDependencies:
+      '@dynamic-labs-wallet/primitives': '>=0.0.336 || 0.0.1'
+
+  '@dynamic-labs-wallet/primitives@0.0.337':
+    resolution: {integrity: sha512-bhF0KBTQ+Ej/gZN/70fDd/ldy3Srqg/NgxzmKhUxMT31uY7OvCNblZ8r5gS6mjiNt+PhF8WmjOdEI5lCD6AjXQ==}
 
   '@dynamic-labs/assert-package-version@4.52.2':
     resolution: {integrity: sha512-zpc0F5zUOBx0LcJ4iHZz9hSq4cl4rpCeNWzqQ/VrI3nEET+beU7AP/dYDFTIrD3DAE5KfpapK9IDt8ymkwVBmg==}
@@ -161,18 +205,39 @@ packages:
   '@dynamic-labs/assert-package-version@4.77.3':
     resolution: {integrity: sha512-MBMSg/eFrAgAnEhk0U1KdqN8zFny1vyO5HCsHRccyvkH5FuRFisnvT1Q0TKGWfPtB4SJePN9VSJDePW1MJGZIg==}
 
+  '@dynamic-labs/assert-package-version@4.83.1':
+    resolution: {integrity: sha512-wSpNfNxoaUVGGYQWGnvyiEuwoNr5YA9dTQZizvnEyCvI/HfipVsQRJjp63ysbPFmqLUFHvwYEDjcHE/+5/V62w==}
+
   '@dynamic-labs/embedded-wallet-evm@4.52.2':
     resolution: {integrity: sha512-nxinY85HRZCKwtlC3yL2e9PJp74tD6ZXB4THF9DL32QOySCiFuXvsftekcFzyrPN1J7nyAJBe++tnW785sxzcA==}
     peerDependencies:
       viem: ^2.28.4
 
+  '@dynamic-labs/embedded-wallet-solana@4.52.2':
+    resolution: {integrity: sha512-5fEiTdPU2QaeNYxPQ1BvRcD+i9W2l1WVV7akS8WhCKdzi2B5V2l9/EP/+NC6EPHarPzgfz+omVYl9lsQmPIzVA==}
+
   '@dynamic-labs/embedded-wallet@4.52.2':
     resolution: {integrity: sha512-oAp1ugcux6Ao2CyehhVXTYkiH9jrxBaCPmrSkp0kwJfitrGd92j6AkFgymI5gtNG/vLXjd2z/KcF+r9uNTedZQ==}
+
+  '@dynamic-labs/ethereum-aa-core@4.83.1':
+    resolution: {integrity: sha512-XhxzO3LZUmek5IMNZjGzlEd5Rm6dCaSuAgBbn+Z+k74Yvaf4WtmE41rzkQZXTnMKTt9WX5XwmzTgTh1gJPlXIA==}
+    peerDependencies:
+      viem: ^2.45.3
+
+  '@dynamic-labs/ethereum-aa@4.83.1':
+    resolution: {integrity: sha512-mnxm99ZY6yVGTvS1CxeOStoH/Y6TB77wHAZGQbtm8u3jIYUjRCtq+k8Q1LWd50jbw3Cog/igMleQB7qhBqQ3SQ==}
+    peerDependencies:
+      viem: ^2.45.3
 
   '@dynamic-labs/ethereum-core@4.52.2':
     resolution: {integrity: sha512-Ly3ILM5YXjs84g5UZfxkgbmodcr34IGI9mYiJQr7XGgMt/HhDOXySeDxo+rwkeWZxFctCFtbOZ1U46O4+XstBQ==}
     peerDependencies:
       viem: ^2.28.4
+
+  '@dynamic-labs/ethereum-core@4.83.1':
+    resolution: {integrity: sha512-xPuxfgzBtj+KGjjOKN/2N3W171rOj9JFKfa92oDLTLv4jt9rfOPottUYgMGf4MGhqWnu8cbnbBlRr5DWukUqhA==}
+    peerDependencies:
+      viem: ^2.45.3
 
   '@dynamic-labs/ethereum@4.52.2':
     resolution: {integrity: sha512-cxrJciTzy7WOi8qGA+l3yD4dRYlwFuRt5UBxzHjty8g9q3rxlwwDja3aaC8XIfeUmEYv47soZ1st17dxwrO8yQ==}
@@ -181,6 +246,12 @@ packages:
 
   '@dynamic-labs/iconic@4.52.2':
     resolution: {integrity: sha512-QHgiTGFcArcboYlOUknlB3X4sKY3S2MrBD+F3UGu5MxrPDUsE2Icloh0DQ1vWia7oND71hbTcf1NOpAKR1EBiQ==}
+    peerDependencies:
+      react: '>=18.0.0 <20.0.0'
+      react-dom: '>=18.0.0 <20.0.0'
+
+  '@dynamic-labs/iconic@4.83.1':
+    resolution: {integrity: sha512-tYU1XYsI426LRnRp1ID1MybyXTitBXNTOZ+SKOWrNzqSnC503li6d4dm7pjuWAT0OZlpMlGw2bL0ZpV66Uojqw==}
     peerDependencies:
       react: '>=18.0.0 <20.0.0'
       react-dom: '>=18.0.0 <20.0.0'
@@ -194,6 +265,9 @@ packages:
   '@dynamic-labs/logger@4.77.3':
     resolution: {integrity: sha512-WnIceyRiW5Nb4QEbB5FdeH10k4q8DAnXTPf7Nvd8+c3rgzS1srdaQTdcgr8tbe1YP6LmIPm50hmUOJP6WErRYA==}
 
+  '@dynamic-labs/logger@4.83.1':
+    resolution: {integrity: sha512-rT8Wsx2EJbnPosbTVIgUWHxHfQ5x8mOnBmcGmVwB3jhPa809sJDJ/+QrvTj0Fsoz80XvmseoHoTKSgIv6XpWVg==}
+
   '@dynamic-labs/message-transport@4.77.3':
     resolution: {integrity: sha512-SvqeyLz2xxsWbs8qnAwjaRMLttEefeOaqtUSdp2JNG4nPPt1+lkCpvWKgspeSF/96yKModdShhUQLutriFpMOg==}
 
@@ -202,6 +276,9 @@ packages:
 
   '@dynamic-labs/rpc-providers@4.52.2':
     resolution: {integrity: sha512-fdv0W+kzd4tnici0lDFWcNtg2mZHZBSrQdUsbrrBSpdENnzk3pqNkJP/keLMAwIYH397C3qbK4my0BoQzROPwQ==}
+
+  '@dynamic-labs/rpc-providers@4.83.1':
+    resolution: {integrity: sha512-KghsNAHBwoRoKN/FPuUfT1yQ+Kf7KhxuHcsH+XINfA90/zMLQrOKIsKeUyBboWWwCJrqCcGsG+lqUmxbCrBasw==}
 
   '@dynamic-labs/sdk-api-core@0.0.764':
     resolution: {integrity: sha512-79JptJTTClLc9qhioThtwMuzTHJ+mrj8sTEglb7Mcx3lJub9YbXqNdzS9mLRxZsr2et3aqqpzymXdUBzSEaMng==}
@@ -212,8 +289,17 @@ packages:
   '@dynamic-labs/sdk-api-core@0.0.843':
     resolution: {integrity: sha512-+4tcNWsKuPzt+suJax3jprwyI+w2gbEbSkzeuvI9/x1B9AuFPvIMxILoVqK9hEsrT57APQHnmTOkxSNk7aDgPA==}
 
+  '@dynamic-labs/sdk-api-core@0.0.900':
+    resolution: {integrity: sha512-4kb6IY75fFbTLwW24hN8ziVuxEeGAtsQpvXlKXA/XYrPKFFtJU6VQnuiKrKAerekIltdfMXEIqBJpcdPsmbszg==}
+
   '@dynamic-labs/sdk-api-core@0.0.927':
     resolution: {integrity: sha512-jL0XRN9GzKeN2wcppD8Ixt2Q7VtkNSbBv6up6el8vutsiQ8ZxA/eX/Wb1ysw8TXiIcDUl2p0afyWwkSxIj+8rw==}
+
+  '@dynamic-labs/sdk-api-core@0.0.958':
+    resolution: {integrity: sha512-jbDSjxWi69Nb5ZRmMrt+tV1gqGoPflvZnw7Qlpmbxbfguqx8KBzvDdDphMJ5jW2YCEmD8dRw2qizOrnN1gjIxw==}
+
+  '@dynamic-labs/sdk-api-core@0.0.964':
+    resolution: {integrity: sha512-U7PdyUQXdvToWCoysBIURYDMy+3XTnGZsdruv1Bl1LKwXHNbR8jGwIt6ibf0vbp1lQga6fc4DPnlAjbtUHaPIA==}
 
   '@dynamic-labs/sdk-react-core@4.52.2':
     resolution: {integrity: sha512-Xk2f6UcIOY3QbXRlwhizHF6Gd+PRMjuIuW4DbKIMfrz8WGKyKF/Qh7AQTJ3ReKYm1KevCbCNLsn0c14/p3F9sA==}
@@ -223,6 +309,9 @@ packages:
 
   '@dynamic-labs/solana-core@4.52.2':
     resolution: {integrity: sha512-BDenb4mDIR4naQRZ2fg9XpKZEvyZujinq/TkfRsAzvoWQkOjLXY3SwxCtUhTEBh48VF+rTFVd8+SAPpoMpUntQ==}
+
+  '@dynamic-labs/solana@4.52.2':
+    resolution: {integrity: sha512-Ni24LTAyHmWeeftmM1gEGQDyuSsgM6QLvB/Ux6DG5s+hIyiXBqa6+n5jTww6KHKn49qZ8LKTdt2Mn658hVZNjA==}
 
   '@dynamic-labs/store@4.52.2':
     resolution: {integrity: sha512-Kt+DqcP8QaILXTX/1TjwyQEDupU+SAV5ZL92CYsuGqqDYftOC21nBlIFz7fEYx4eUn/v+w+iEvJ5qd8Hbm7OlA==}
@@ -236,14 +325,23 @@ packages:
   '@dynamic-labs/types@4.77.3':
     resolution: {integrity: sha512-tP45k6blfuuWDt8Vua+ZcvxM3DxkiieIg7vSt5aXUgBbaFFygnz98d1u+n1PD9np2NqDWyCUjMJE71Uk2HLrFg==}
 
+  '@dynamic-labs/types@4.83.1':
+    resolution: {integrity: sha512-lwNz57iJLk/bySkGVxeYIbWZvmb18s9yD2QbXQguyChu6V4/PdoRH4DGBr9xxOMY06zzSVSN3g2ctrsepv4atg==}
+
   '@dynamic-labs/utils@4.52.2':
     resolution: {integrity: sha512-3rvKPjjc7zvC8E30E5UYSfx0ZBjNNKqziJDw/N0p5KvbIWech4y5xHkaNmW6vxWTRT89trwtbtyrPJuRoK3rsg==}
 
   '@dynamic-labs/utils@4.77.3':
     resolution: {integrity: sha512-UeSy8YYvbKwMbCmVkcxrVb9f7k0Oe5MYn2R6k1+phsgG4Zfst8IyN/d4KgKDSBZaeKnYN5z+ZekgBLJzeRtA5g==}
 
+  '@dynamic-labs/utils@4.83.1':
+    resolution: {integrity: sha512-6PgT0Xr8IQUn4xx3fBn2XEcyA9NAnR/BSVEsOb/+KgFRhx7bmKkwC3Bh1ooCXpr9P/osutT9Yy+Eb/3rg182CA==}
+
   '@dynamic-labs/waas-evm@4.52.2':
     resolution: {integrity: sha512-rWn+1aFWK0a/95wEiyg1qyusTJvxC6VKiIdITNsXeLZkBXkMy8HFPHeD5lBjW8mVOn5HRcAGHLYAYfpINSncfw==}
+
+  '@dynamic-labs/waas-svm@4.52.2':
+    resolution: {integrity: sha512-6B/mRgwCJIu8Ir00EYHXapwTQGR/ahQvbfYIkMqfOtl6wZDoBd1f4zJO3GLPnYcErG7DKdYVW2hY6/bR/0KL2w==}
 
   '@dynamic-labs/waas@4.52.2':
     resolution: {integrity: sha512-qreXLXnCxdVKItdWrbmxfbMV0ybRqFS+qDUDueXmze3pR2+pZgCw1yhAhCayQ9nQQFFJUZxzWqQhAXszJXxPHQ==}
@@ -254,8 +352,20 @@ packages:
       react: '>=18.0.0 <20.0.0'
       react-dom: '>=18.0.0 <20.0.0'
 
+  '@dynamic-labs/wallet-book@4.83.1':
+    resolution: {integrity: sha512-FNCQsS8U1l2SgvbZAESJcBcVcVJ7EeQrazNiEIKze4gcAwlJXDMoa/ThbN/dUOGaY1smM0A8TOKiBER96+t7OA==}
+    peerDependencies:
+      react: '>=18.0.0 <20.0.0'
+      react-dom: '>=18.0.0 <20.0.0'
+
+  '@dynamic-labs/wallet-connect@4.52.2':
+    resolution: {integrity: sha512-h4nSQdkfRnT82wHPsv1gFk3V7wLmL0dMRtglkhri3cghIHwSfCaW0AYLArhojEQ68gitnvS42oWfeC+QE0waWg==}
+
   '@dynamic-labs/wallet-connector-core@4.52.2':
     resolution: {integrity: sha512-bAINAsC4Ydz7/UjctOrRSNZG8xhg7YZQkMLnz0uX5t/hB71UiFpnU890bJQJg95YjYHsHmHw1PUBCCI6sONnHw==}
+
+  '@dynamic-labs/wallet-connector-core@4.83.1':
+    resolution: {integrity: sha512-lYAuLgMB8aKqT+M+vftUslIy5YlArs4LxcwCHZgQNoly1UB9CEjGSJFQBQmZQIrmz7TB+8H8V11uHhGu/Ow3IQ==}
 
   '@dynamic-labs/webauthn@4.52.2':
     resolution: {integrity: sha512-RytiwqsCWB8TiYFr8Xb3cj7JmumUMyz2wz49phK/wA5WS2F/t6OUt4cW/QMBEfVhgvq1YOIn7fKuFFlsTeDv4A==}
@@ -860,6 +970,10 @@ packages:
     resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@1.8.2':
+    resolution: {integrity: sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.9.0':
     resolution: {integrity: sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==}
     engines: {node: ^14.21.3 || >=16}
@@ -890,6 +1004,10 @@ packages:
 
   '@noble/hashes@1.7.1':
     resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.7.2':
+    resolution: {integrity: sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.8.0':
@@ -1280,9 +1398,27 @@ packages:
   '@simplewebauthn/browser@13.1.0':
     resolution: {integrity: sha512-WuHZ/PYvyPJ9nxSzgHtOEjogBhwJfC8xzYkPC+rR/+8chl/ft4ngjiK8kSU5HtRJfczupyOh33b25TjYbvwAcg==}
 
+  '@simplewebauthn/browser@8.3.7':
+    resolution: {integrity: sha512-ZtRf+pUEgOCvjrYsbMsJfiHOdKcrSZt2zrAnIIpfmA06r0FxBovFYq0rJ171soZbe13KmWzAoLKjSxVW7KxCdQ==}
+
+  '@simplewebauthn/browser@9.0.1':
+    resolution: {integrity: sha512-wD2WpbkaEP4170s13/HUxPcAV5y4ZXaKo1TfNklS5zDefPinIgXOpgz1kpEvobAsaLPa2KeH7AKKX/od1mrBJw==}
+
   '@simplewebauthn/types@12.0.0':
     resolution: {integrity: sha512-q6y8MkoV8V8jB4zzp18Uyj2I7oFp2/ONL8c3j8uT06AOWu3cIChc1au71QYHrP2b+xDapkGTiv+9lX7xkTlAsA==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  '@simplewebauthn/types@9.0.1':
+    resolution: {integrity: sha512-tGSRP1QvsAvsJmnOlRQyw/mvK9gnPtjEc5fg2+m8n+QUa+D7rvrKkOYyfpy42GTs90X3RDOnqJgfHt+qO67/+w==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  '@simplewebauthn/typescript-types@8.3.4':
+    resolution: {integrity: sha512-38xtca0OqfRVNloKBrFB5LEM6PN5vzFbJG6rAutPVrtGHFYxPdiV3btYWq0eAZAZmP+dqFPYJxJWeJrGfmYHng==}
+    deprecated: This package has been renamed to @simplewebauthn/types. Please install @simplewebauthn/types instead to ensure you receive future updates.
+
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
@@ -1377,6 +1513,10 @@ packages:
 
   '@swc/helpers@0.5.20':
     resolution: {integrity: sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==}
+
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
 
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
@@ -1518,6 +1658,10 @@ packages:
     resolution: {integrity: sha512-w9WLK8rMBLMIQNtaEriW2mQRuRxWu5GCOZatReaB5FRrtUFJroXjB3V8C+wUER02w3znyZzklQGPL1P32n6iuA==}
     engines: {node: '>=18.0.0'}
 
+  '@turnkey/solana@1.0.42':
+    resolution: {integrity: sha512-+SxerY0mAfdoak61biZxr7D+izqnYLrhfCfXxHcHG1lp+cG1u22eyx4zcrjLbzwmUBQ30Iu32kLMTVu+/b5AzA==}
+    engines: {node: '>=18.0.0'}
+
   '@turnkey/viem@0.13.0':
     resolution: {integrity: sha512-l0PngrJlCgRvnuahYxPOhTB0SfiIAMHpX8fZOC3f7hEa1g1p4sN2RUAAm5rHI0KCXuLf5j4YWRUI6p6q2QC8tw==}
     engines: {node: '>=18.0.0'}
@@ -1534,6 +1678,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/cacheable-request@6.0.3':
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -1543,11 +1690,17 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/keyv@3.1.4':
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
@@ -1568,6 +1721,9 @@ packages:
 
   '@types/react@19.1.12':
     resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
+
+  '@types/responselike@1.0.3':
+    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1749,8 +1905,16 @@ packages:
   '@vue/shared@3.5.31':
     resolution: {integrity: sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==}
 
+  '@wallet-standard/app@1.0.1':
+    resolution: {integrity: sha512-LnLYq2Vy2guTZ8GQKKSXQK3+FRGPil75XEdkZqE6fiLixJhZJoJa5hT7lXxwe0ykVTt9LEThdTbOpT7KadS26Q==}
+    engines: {node: '>=16'}
+
   '@wallet-standard/app@1.1.0':
     resolution: {integrity: sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==}
+    engines: {node: '>=16'}
+
+  '@wallet-standard/base@1.0.1':
+    resolution: {integrity: sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==}
     engines: {node: '>=16'}
 
   '@wallet-standard/base@1.1.0':
@@ -1765,6 +1929,14 @@ packages:
     resolution: {integrity: sha512-V8Ju1Wvol8i/VDyQOHhjhxmMVwmKiwyxUZBnHhtiPZJTWY0U/Shb2iEWyGngYEbAkp2sGTmEeNX1tVyGR7PqNw==}
     engines: {node: '>=16'}
     hasBin: true
+
+  '@wallet-standard/experimental-features@0.1.1':
+    resolution: {integrity: sha512-WKtnET1okeDACTbxmePGOGaIUrGvlu/DestLZvZ/ddFpUKw7nokkbinX/gHzsuAC9WGtLyhqLSppAHzN+vAAaQ==}
+    engines: {node: '>=16'}
+
+  '@wallet-standard/features@1.0.3':
+    resolution: {integrity: sha512-m8475I6W5LTatTZuUz5JJNK42wFRgkJTB0I9tkruMwfqBF2UN2eomkYNVf9RbrsROelCRzSFmugqjKZBFaubsA==}
+    engines: {node: '>=16'}
 
   '@wallet-standard/features@1.1.0':
     resolution: {integrity: sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==}
@@ -1867,6 +2039,29 @@ packages:
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
 
+  '@zerodev/ecdsa-validator@5.4.9':
+    resolution: {integrity: sha512-9NVE8/sQIKRo42UOoYKkNdmmHJY8VlT4t+2MHD2ipLg21cpbY9fS17TGZh61+Bl3qlqc8pP23I6f89z9im7kuA==}
+    peerDependencies:
+      '@zerodev/sdk': ^5.4.13
+      viem: ^2.28.0
+
+  '@zerodev/multi-chain-ecdsa-validator@5.4.5':
+    resolution: {integrity: sha512-cmQcsl5WbjnyQuhAS76BUqsHGtUOfWqdkMlm60s75kmRKzF5PiKzRpWIZyeISVmJV0F4P5u1keo1xYONEFiw1w==}
+    peerDependencies:
+      '@zerodev/sdk': ^5.4.0
+      '@zerodev/webauthn-key': ^5.4.0
+      viem: ^2.28.0
+
+  '@zerodev/sdk@5.5.7':
+    resolution: {integrity: sha512-Sf4G13yi131H8ujun64obvXIpk1UWn64GiGJjfvGx8aIKg+OWTRz9AZHgGKK+bE/evAmqIg4nchuSvKPhOau1w==}
+    peerDependencies:
+      viem: ^2.28.0
+
+  '@zerodev/webauthn-key@5.5.0':
+    resolution: {integrity: sha512-AbD2d/qrsX7AWxJMEfwxnLbp1TjiUjc1V4ne3Q40UJxKe+lW64Td+y8OD0qSFMqgN6rQxJZ0aOAXmat8H6xluA==}
+    peerDependencies:
+      viem: ^2.28.0
+
   abitype@1.0.8:
     resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
     peerDependencies:
@@ -1887,6 +2082,18 @@ packages:
       typescript:
         optional: true
       zod:
+        optional: true
+
+  ably@2.17.1:
+    resolution: {integrity: sha512-70yfXHoM7JtJD/8FCtPD1gkWW0f+AJqbJp0PsqDAqiyxFB8cPFY+FuKHgNTYb8eRHKXq8hT1xiDphUcY0+GHnA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
         optional: true
 
   acorn-jsx@5.3.2:
@@ -1996,6 +2203,12 @@ packages:
   axios@1.13.2:
     resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
 
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+
   axios@1.9.0:
     resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
 
@@ -2018,6 +2231,10 @@ packages:
 
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
+
+  base64-js@1.0.2:
+    resolution: {integrity: sha512-ZXBDPMt/v/8fsIqn+Z5VwrhdR6jVka0bYobHdGia0Nxi7BJ9i/Uvml3AocHIBtIIBhZjBw5MR0aR4ROs/8+SNg==}
+    engines: {node: '>= 0.4'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2043,8 +2260,14 @@ packages:
   blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
 
+  bn.js@4.11.6:
+    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
+
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
+
+  bops@1.0.1:
+    resolution: {integrity: sha512-qCMBuZKP36tELrrgXpAfM+gHzqa0nLsWZ+L37ncsb8txYlnAoxOPpVp+g7fK0sGkMXfA0wl8uQkESqw3v4HNag==}
 
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
@@ -2080,12 +2303,23 @@ packages:
   bs58check@4.0.0:
     resolution: {integrity: sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==}
 
+  buffer-reverse@1.0.1:
+    resolution: {integrity: sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bufferutil@4.1.0:
     resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
     engines: {node: '>=6.14.2'}
+
+  cacheable-lookup@5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2130,6 +2364,9 @@ packages:
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
   clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
@@ -2202,6 +2439,9 @@ packages:
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2252,12 +2492,20 @@ packages:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   deepmerge@2.2.1:
     resolution: {integrity: sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==}
     engines: {node: '>=0.10.0'}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -2281,6 +2529,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   derive-valtio@0.1.0:
     resolution: {integrity: sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==}
@@ -2519,8 +2771,15 @@ packages:
   eth-rpc-errors@4.0.3:
     resolution: {integrity: sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==}
 
+  ethereum-bloom-filters@1.2.0:
+    resolution: {integrity: sha512-28hyiE7HVsWubqhpVLVmZXFd4ITeHi+BUu05o9isf0GUpMtzBUi+8/gFrGaGYzvGAJQmJ3JKj77Mk9G98T84rA==}
+
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
+
+  ethjs-unit@0.1.6:
+    resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
 
   eventemitter2@6.4.9:
     resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
@@ -2670,6 +2929,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -2696,6 +2959,10 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
 
   gql.tada@1.9.1:
     resolution: {integrity: sha512-Ijtwgw08aE7l06wK5oj5Msgpk9SUe5FSVcuxU5dHyefdM7fDqLQpA76yHBoq8lPB3MNSir8tznodDknHkm2Z/w==}
@@ -2750,9 +3017,16 @@ packages:
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
+
+  http2-wrapper@1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -2861,6 +3135,10 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hex-prefixed@1.0.0:
+    resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -3105,6 +3383,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
+
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
@@ -3125,6 +3407,10 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  merkletreejs@0.3.11:
+    resolution: {integrity: sha512-LJKTl4iVNTndhL+3Uz/tfkjD0klIWsHlUzgtuNnNrsf7bAlXR30m+xYB7lHr5Z/l6e/yAIsr26Dabx6Buo4VGQ==}
+    engines: {node: '>= 7.6.0'}
+
   micro-ftch@0.3.1:
     resolution: {integrity: sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==}
 
@@ -3139,6 +3425,14 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -3222,6 +3516,14 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+
+  number-to-bn@1.7.0:
+    resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
 
   obj-multiplex@1.0.0:
     resolution: {integrity: sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA==}
@@ -3312,6 +3614,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -3423,8 +3729,15 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode@1.3.2:
+    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3444,14 +3757,26 @@ packages:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
 
+  querystring@0.2.0:
+    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
   react-clientside-effect@1.2.8:
     resolution: {integrity: sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==}
@@ -3560,6 +3885,9 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3576,6 +3904,9 @@ packages:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -3765,6 +4096,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-hex-prefix@1.0.0:
+    resolution: {integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -3832,6 +4167,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  to-utf8@0.0.1:
+    resolution: {integrity: sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ==}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -3841,6 +4179,10 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  treeify@1.1.0:
+    resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
+    engines: {node: '>=0.6'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -3859,6 +4201,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -3893,6 +4238,10 @@ packages:
 
   uint8arrays@3.1.1:
     resolution: {integrity: sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==}
+
+  ulid@2.4.0:
+    resolution: {integrity: sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==}
+    hasBin: true
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -3978,6 +4327,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url@0.11.0:
+    resolution: {integrity: sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -4010,6 +4362,9 @@ packages:
   utf-8-validate@6.0.6:
     resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
     engines: {node: '>=6.14.2'}
+
+  utf8@3.0.0:
+    resolution: {integrity: sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -4052,6 +4407,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.29.0:
+    resolution: {integrity: sha512-N6GeIuuay/spDyw+5FbSuNIkVN0da+jGOjdlC0bdatIN+N0jtOf9Zfj0pbXgpIJGwnM9ocxzTRt0HZVbHBdL2Q==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@2.31.0:
     resolution: {integrity: sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA==}
     peerDependencies:
@@ -4071,6 +4434,10 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  web3-utils@1.10.4:
+    resolution: {integrity: sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==}
+    engines: {node: '>=8.0.0'}
 
   webextension-polyfill@0.10.0:
     resolution: {integrity: sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==}
@@ -4130,6 +4497,18 @@ packages:
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.1:
+    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4238,6 +4617,10 @@ snapshots:
       graphql: 16.13.2
       typescript: 5.9.3
 
+  '@ably/msgpack-js@0.4.1':
+    dependencies:
+      bops: 1.0.1
+
   '@adraffy/ens-normalize@1.11.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
@@ -4295,6 +4678,8 @@ snapshots:
 
   '@dynamic-labs-sdk/assert-package-version@0.1.2': {}
 
+  '@dynamic-labs-sdk/assert-package-version@0.26.9': {}
+
   '@dynamic-labs-sdk/client@0.1.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@dynamic-labs-sdk/assert-package-version': 0.1.2
@@ -4309,10 +4694,28 @@ snapshots:
       - debug
       - utf-8-validate
 
+  '@dynamic-labs-sdk/client@0.26.9(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@dynamic-labs-sdk/assert-package-version': 0.26.9
+      '@dynamic-labs-wallet/browser-wallet-client': 0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@dynamic-labs/sdk-api-core': 0.0.958
+      '@simplewebauthn/browser': 13.1.0
+      ably: 2.17.1(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      zod: 4.0.5
+    transitivePeerDependencies:
+      - '@dynamic-labs-wallet/forward-mpc-client'
+      - bufferutil
+      - debug
+      - react
+      - react-dom
+      - utf-8-validate
+
   '@dynamic-labs-wallet/browser-wallet-client@0.0.211(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@dynamic-labs-wallet/core': 0.0.211(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/logger': 4.52.2
+      '@dynamic-labs/logger': 4.83.1
       '@dynamic-labs/message-transport': 4.77.3
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -4323,7 +4726,7 @@ snapshots:
   '@dynamic-labs-wallet/browser-wallet-client@0.0.217(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@dynamic-labs-wallet/core': 0.0.217(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/logger': 4.52.2
+      '@dynamic-labs/logger': 4.83.1
       '@dynamic-labs/message-transport': 4.77.3
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -4331,10 +4734,28 @@ snapshots:
       - debug
       - utf-8-validate
 
+  '@dynamic-labs-wallet/browser-wallet-client@0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@dynamic-labs-wallet/core': 0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/message-transport': 4.77.3
+    transitivePeerDependencies:
+      - '@dynamic-labs-wallet/forward-mpc-client'
+      - debug
+
+  '@dynamic-labs-wallet/browser-wallet-client@0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@dynamic-labs-wallet/core': 0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/message-transport': 4.77.3
+    transitivePeerDependencies:
+      - '@dynamic-labs-wallet/forward-mpc-client'
+      - debug
+
   '@dynamic-labs-wallet/browser@0.0.167':
     dependencies:
       '@dynamic-labs-wallet/core': 0.0.167
-      '@dynamic-labs/logger': 4.52.2
+      '@dynamic-labs/logger': 4.83.1
       '@dynamic-labs/sdk-api-core': 0.0.764
       '@noble/hashes': 1.7.1
       argon2id: 1.0.1
@@ -4356,7 +4777,7 @@ snapshots:
   '@dynamic-labs-wallet/core@0.0.211(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@dynamic-labs-wallet/forward-mpc-client': 0.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/logger': 4.52.2
+      '@dynamic-labs/logger': 4.83.1
       '@dynamic-labs/sdk-api-core': 0.0.818
       axios: 1.13.2
       http-errors: 2.0.0
@@ -4369,7 +4790,7 @@ snapshots:
   '@dynamic-labs-wallet/core@0.0.217(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@dynamic-labs-wallet/forward-mpc-client': 0.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/logger': 4.52.2
+      '@dynamic-labs/logger': 4.83.1
       '@dynamic-labs/sdk-api-core': 0.0.818
       axios: 1.13.2
       http-errors: 2.0.0
@@ -4378,6 +4799,25 @@ snapshots:
       - bufferutil
       - debug
       - utf-8-validate
+
+  '@dynamic-labs-wallet/core@0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@dynamic-labs/sdk-api-core': 0.0.900
+      axios: 1.15.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+
+  '@dynamic-labs-wallet/core@0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@dynamic-labs-wallet/primitives': 0.0.337
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      axios: 1.15.2
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
 
   '@dynamic-labs-wallet/forward-mpc-client@0.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
@@ -4394,6 +4834,20 @@ snapshots:
       - debug
       - utf-8-validate
 
+  '@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@dynamic-labs-wallet/forward-mpc-shared': 0.7.0(@dynamic-labs-wallet/primitives@0.0.337)
+      '@dynamic-labs-wallet/primitives': 0.0.337
+      '@evervault/wasm-attestation-bindings': 0.3.1
+      '@noble/hashes': 2.0.1
+      eventemitter3: 5.0.1
+      fp-ts: 2.16.11
+      isows: 1.0.7(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@dynamic-labs-wallet/forward-mpc-shared@0.1.0':
     dependencies:
       '@dynamic-labs-wallet/browser': 0.0.167
@@ -4406,6 +4860,17 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@dynamic-labs-wallet/forward-mpc-shared@0.7.0(@dynamic-labs-wallet/primitives@0.0.337)':
+    dependencies:
+      '@dynamic-labs-wallet/primitives': 0.0.337
+      '@noble/ciphers': 0.4.1
+      '@noble/hashes': 2.0.1
+      '@noble/post-quantum': 0.5.4
+      fp-ts: 2.16.11
+      io-ts: 2.2.22(fp-ts@2.16.11)
+
+  '@dynamic-labs-wallet/primitives@0.0.337': {}
+
   '@dynamic-labs/assert-package-version@4.52.2':
     dependencies:
       '@dynamic-labs/logger': 4.52.2
@@ -4413,6 +4878,10 @@ snapshots:
   '@dynamic-labs/assert-package-version@4.77.3':
     dependencies:
       '@dynamic-labs/logger': 4.77.3
+
+  '@dynamic-labs/assert-package-version@4.83.1':
+    dependencies:
+      '@dynamic-labs/logger': 4.83.1
 
   '@dynamic-labs/embedded-wallet-evm@4.52.2(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
     dependencies:
@@ -4439,6 +4908,35 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@dynamic-labs/embedded-wallet-solana@4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)':
+    dependencies:
+      '@dynamic-labs-sdk/client': 0.1.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@dynamic-labs/assert-package-version': 4.52.2
+      '@dynamic-labs/embedded-wallet': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/rpc-providers': 4.52.2
+      '@dynamic-labs/sdk-api-core': 0.0.843
+      '@dynamic-labs/solana-core': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@dynamic-labs/types': 4.52.2
+      '@dynamic-labs/utils': 4.52.2
+      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/webauthn': 4.52.2
+      '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@turnkey/iframe-stamper': 2.5.0
+      '@turnkey/solana': 1.0.42(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+      '@turnkey/webauthn-stamper': 0.5.1
+      viem: 2.29.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - react
+      - react-dom
+      - typescript
+      - utf-8-validate
+      - zod
+
   '@dynamic-labs/embedded-wallet@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.52.2
@@ -4457,6 +4955,48 @@ snapshots:
       - react
       - react-dom
 
+  '@dynamic-labs/ethereum-aa-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/ethereum-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+    transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
+      - bufferutil
+      - debug
+      - react
+      - react-dom
+      - utf-8-validate
+
+  '@dynamic-labs/ethereum-aa@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(@zerodev/webauthn-key@5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/ethereum-aa-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/ethereum-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@zerodev/ecdsa-validator': 5.4.9(@zerodev/sdk@5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@zerodev/multi-chain-ecdsa-validator': 5.4.5(@zerodev/sdk@5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(@zerodev/webauthn-key@5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@zerodev/sdk': 5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+    transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
+      - '@zerodev/webauthn-key'
+      - bufferutil
+      - debug
+      - react
+      - react-dom
+      - utf-8-validate
+
   '@dynamic-labs/ethereum-core@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.52.2
@@ -4471,6 +5011,25 @@ snapshots:
     transitivePeerDependencies:
       - react
       - react-dom
+
+  '@dynamic-labs/ethereum-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+    transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
+      - bufferutil
+      - debug
+      - react
+      - react-dom
+      - utf-8-validate
 
   '@dynamic-labs/ethereum@4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
     dependencies:
@@ -4535,6 +5094,15 @@ snapshots:
       react-dom: 19.1.2(react@19.1.2)
       sharp: 0.33.5
 
+  '@dynamic-labs/iconic@4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
+      react: 19.1.2
+      react-dom: 19.1.2(react@19.1.2)
+      sharp: 0.33.5
+      url: 0.11.0
+
   '@dynamic-labs/locale@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.52.2
@@ -4550,6 +5118,10 @@ snapshots:
       eventemitter3: 5.0.1
 
   '@dynamic-labs/logger@4.77.3':
+    dependencies:
+      eventemitter3: 5.0.1
+
+  '@dynamic-labs/logger@4.83.1':
     dependencies:
       eventemitter3: 5.0.1
 
@@ -4580,13 +5152,24 @@ snapshots:
       '@dynamic-labs/assert-package-version': 4.52.2
       '@dynamic-labs/types': 4.52.2
 
+  '@dynamic-labs/rpc-providers@4.83.1':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/types': 4.83.1
+
   '@dynamic-labs/sdk-api-core@0.0.764': {}
 
   '@dynamic-labs/sdk-api-core@0.0.818': {}
 
   '@dynamic-labs/sdk-api-core@0.0.843': {}
 
+  '@dynamic-labs/sdk-api-core@0.0.900': {}
+
   '@dynamic-labs/sdk-api-core@0.0.927': {}
+
+  '@dynamic-labs/sdk-api-core@0.0.958': {}
+
+  '@dynamic-labs/sdk-api-core@0.0.964': {}
 
   '@dynamic-labs/sdk-react-core@4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
     dependencies:
@@ -4645,6 +5228,64 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@dynamic-labs/solana@4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.52.2
+      '@dynamic-labs/embedded-wallet-solana': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+      '@dynamic-labs/logger': 4.52.2
+      '@dynamic-labs/rpc-providers': 4.52.2
+      '@dynamic-labs/sdk-api-core': 0.0.843
+      '@dynamic-labs/solana-core': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@dynamic-labs/types': 4.52.2
+      '@dynamic-labs/utils': 4.52.2
+      '@dynamic-labs/waas-svm': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connect': 4.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@wallet-standard/app': 1.0.1
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/experimental-features': 0.1.1
+      '@wallet-standard/features': 1.0.3
+      '@walletconnect/sign-client': 2.21.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+      '@walletconnect/types': 2.21.5
+      '@walletconnect/utils': 2.21.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+      bs58: 5.0.0
+      eventemitter3: 5.0.1
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - ioredis
+      - react
+      - react-dom
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - viem
+      - zod
+
   '@dynamic-labs/store@4.52.2':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.52.2
@@ -4680,6 +5321,11 @@ snapshots:
       '@dynamic-labs/assert-package-version': 4.77.3
       '@dynamic-labs/sdk-api-core': 0.0.927
 
+  '@dynamic-labs/types@4.83.1':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+
   '@dynamic-labs/utils@4.52.2':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.52.2
@@ -4696,6 +5342,16 @@ snapshots:
       '@dynamic-labs/logger': 4.77.3
       '@dynamic-labs/sdk-api-core': 0.0.927
       '@dynamic-labs/types': 4.77.3
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      tldts: 6.0.16
+
+  '@dynamic-labs/utils@4.83.1':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
       buffer: 6.0.3
       eventemitter3: 5.0.1
       tldts: 6.0.16
@@ -4723,6 +5379,33 @@ snapshots:
       - typescript
       - utf-8-validate
       - zod
+
+  '@dynamic-labs/waas-svm@4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.52.2
+      '@dynamic-labs/logger': 4.52.2
+      '@dynamic-labs/rpc-providers': 4.52.2
+      '@dynamic-labs/sdk-api-core': 0.0.843
+      '@dynamic-labs/solana-core': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@dynamic-labs/types': 4.52.2
+      '@dynamic-labs/utils': 4.52.2
+      '@dynamic-labs/waas': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      bs58: 5.0.0
+      eventemitter3: 5.0.1
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - react
+      - react-dom
+      - typescript
+      - utf-8-validate
+      - viem
 
   '@dynamic-labs/waas@4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
     dependencies:
@@ -4760,6 +5443,48 @@ snapshots:
       util: 0.12.5
       zod: 4.0.5
 
+  '@dynamic-labs/wallet-book@4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/iconic': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      eventemitter3: 5.0.1
+      react: 19.1.2
+      react-dom: 19.1.2(react@19.1.2)
+      util: 0.12.5
+      zod: 4.0.5
+
+  '@dynamic-labs/wallet-connect@4.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.52.2
+      '@dynamic-labs/logger': 4.52.2
+      '@walletconnect/sign-client': 2.21.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@dynamic-labs/wallet-connector-core@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.52.2
@@ -4773,6 +5498,27 @@ snapshots:
     transitivePeerDependencies:
       - react
       - react-dom
+
+  '@dynamic-labs/wallet-connector-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@dynamic-labs-sdk/client': 0.26.9(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs-wallet/browser-wallet-client': 0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      eventemitter3: 5.0.1
+    transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
+      - bufferutil
+      - debug
+      - react
+      - react-dom
+      - utf-8-validate
 
   '@dynamic-labs/webauthn@4.52.2':
     dependencies:
@@ -5357,6 +6103,10 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.7.1
 
+  '@noble/curves@1.8.2':
+    dependencies:
+      '@noble/hashes': 1.7.2
+
   '@noble/curves@1.9.0':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -5382,6 +6132,8 @@ snapshots:
   '@noble/hashes@1.7.0': {}
 
   '@noble/hashes@1.7.1': {}
+
+  '@noble/hashes@1.7.2': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -5946,13 +6698,13 @@ snapshots:
 
   '@scure/bip32@1.6.2':
     dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@scure/base': 1.2.6
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -5963,7 +6715,7 @@ snapshots:
 
   '@scure/bip39@1.5.4':
     dependencies:
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.7.2
       '@scure/base': 1.2.6
 
   '@scure/bip39@1.6.0':
@@ -5973,7 +6725,21 @@ snapshots:
 
   '@simplewebauthn/browser@13.1.0': {}
 
+  '@simplewebauthn/browser@8.3.7':
+    dependencies:
+      '@simplewebauthn/typescript-types': 8.3.4
+
+  '@simplewebauthn/browser@9.0.1':
+    dependencies:
+      '@simplewebauthn/types': 9.0.1
+
   '@simplewebauthn/types@12.0.0': {}
+
+  '@simplewebauthn/types@9.0.1': {}
+
+  '@simplewebauthn/typescript-types@8.3.4': {}
+
+  '@sindresorhus/is@4.6.0': {}
 
   '@socket.io/component-emitter@3.1.2': {}
 
@@ -6126,6 +6892,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
+
   '@tailwindcss/node@4.1.18':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -6275,6 +7045,19 @@ snapshots:
 
   '@turnkey/sdk-types@0.3.0': {}
 
+  '@turnkey/solana@1.0.42(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)':
+    dependencies:
+      '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@turnkey/http': 3.10.0
+      '@turnkey/sdk-browser': 5.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+      '@turnkey/sdk-server': 4.7.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+      - zod
+
   '@turnkey/viem@0.13.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
     dependencies:
       '@noble/curves': 1.8.0
@@ -6313,6 +7096,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/cacheable-request@6.0.3':
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      '@types/keyv': 3.1.4
+      '@types/node': 20.19.27
+      '@types/responselike': 1.0.3
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 20.19.27
@@ -6323,9 +7113,15 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/http-cache-semantics@4.2.0': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/keyv@3.1.4':
+    dependencies:
+      '@types/node': 20.19.27
 
   '@types/lodash@4.17.24': {}
 
@@ -6344,6 +7140,10 @@ snapshots:
   '@types/react@19.1.12':
     dependencies:
       csstype: 3.2.3
+
+  '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 20.19.27
 
   '@types/trusted-types@2.0.7': {}
 
@@ -6513,9 +7313,15 @@ snapshots:
 
   '@vue/shared@3.5.31': {}
 
+  '@wallet-standard/app@1.0.1':
+    dependencies:
+      '@wallet-standard/base': 1.1.0
+
   '@wallet-standard/app@1.1.0':
     dependencies:
       '@wallet-standard/base': 1.1.0
+
+  '@wallet-standard/base@1.0.1': {}
 
   '@wallet-standard/base@1.1.0': {}
 
@@ -6531,6 +7337,14 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       commander: 13.1.0
+
+  '@wallet-standard/experimental-features@0.1.1':
+    dependencies:
+      '@wallet-standard/base': 1.1.0
+
+  '@wallet-standard/features@1.0.3':
+    dependencies:
+      '@wallet-standard/base': 1.1.0
 
   '@wallet-standard/features@1.1.0':
     dependencies:
@@ -7080,6 +7894,32 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
+  '@zerodev/ecdsa-validator@5.4.9(@zerodev/sdk@5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
+    dependencies:
+      '@zerodev/sdk': 5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+
+  '@zerodev/multi-chain-ecdsa-validator@5.4.5(@zerodev/sdk@5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(@zerodev/webauthn-key@5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
+    dependencies:
+      '@simplewebauthn/browser': 9.0.1
+      '@simplewebauthn/typescript-types': 8.3.4
+      '@zerodev/sdk': 5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@zerodev/webauthn-key': 5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      merkletreejs: 0.3.11
+      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+
+  '@zerodev/sdk@5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
+    dependencies:
+      semver: 7.7.4
+      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+
+  '@zerodev/webauthn-key@5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@simplewebauthn/browser': 8.3.7
+      '@simplewebauthn/types': 12.0.0
+      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+
   abitype@1.0.8(typescript@5.9.3)(zod@4.3.5):
     optionalDependencies:
       typescript: 5.9.3
@@ -7094,6 +7934,21 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       zod: 4.3.5
+
+  ably@2.17.1(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6):
+    dependencies:
+      '@ably/msgpack-js': 0.4.1
+      dequal: 2.0.3
+      fastestsmallesttextencoderdecoder: 1.0.22
+      got: 11.8.6
+      ulid: 2.4.0
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      react: 19.1.2
+      react-dom: 19.1.2(react@19.1.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -7231,6 +8086,22 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  axios@1.15.0:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.15.2:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
   axios@1.9.0:
     dependencies:
       follow-redirects: 1.15.11
@@ -7253,6 +8124,8 @@ snapshots:
 
   base-x@5.0.1: {}
 
+  base64-js@1.0.2: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.13: {}
@@ -7271,7 +8144,14 @@ snapshots:
 
   blakejs@1.2.1: {}
 
+  bn.js@4.11.6: {}
+
   bn.js@5.2.3: {}
+
+  bops@1.0.1:
+    dependencies:
+      base64-js: 1.0.2
+      to-utf8: 0.0.1
 
   borsh@0.7.0:
     dependencies:
@@ -7319,6 +8199,8 @@ snapshots:
       '@noble/hashes': 1.8.0
       bs58: 6.0.0
 
+  buffer-reverse@1.0.1: {}
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -7327,6 +8209,18 @@ snapshots:
   bufferutil@4.1.0:
     dependencies:
       node-gyp-build: 4.8.4
+
+  cacheable-lookup@5.0.4: {}
+
+  cacheable-request@7.0.4:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -7373,6 +8267,10 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
 
   clsx@1.2.1: {}
 
@@ -7438,6 +8336,8 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  crypto-js@4.2.0: {}
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
@@ -7478,9 +8378,15 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-is@0.1.4: {}
 
   deepmerge@2.2.1: {}
+
+  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -7501,6 +8407,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.1.12)(react@19.1.2)):
     dependencies:
@@ -7889,12 +8797,21 @@ snapshots:
     dependencies:
       fast-safe-stringify: 2.1.1
 
+  ethereum-bloom-filters@1.2.0:
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   ethereum-cryptography@2.2.1:
     dependencies:
       '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
+
+  ethjs-unit@0.1.6:
+    dependencies:
+      bn.js: 4.11.6
+      number-to-bn: 1.7.0
 
   eventemitter2@6.4.9: {}
 
@@ -8038,6 +8955,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -8064,6 +8985,20 @@ snapshots:
       gopd: 1.2.0
 
   gopd@1.2.0: {}
+
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
 
   gql.tada@1.9.1(graphql@16.13.2)(typescript@5.9.3):
     dependencies:
@@ -8131,6 +9066,8 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
+  http-cache-semantics@4.2.0: {}
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -8138,6 +9075,11 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
+
+  http2-wrapper@1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
 
   humanize-ms@1.2.1:
     dependencies:
@@ -8249,6 +9191,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hex-prefixed@1.0.0: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -8315,6 +9259,10 @@ snapshots:
     dependencies:
       ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
+  isows@1.0.6(ws@8.18.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 8.18.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
   isows@1.0.7(ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       ws: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -8322,6 +9270,10 @@ snapshots:
   isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
+  isows@1.0.7(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -8477,6 +9429,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lowercase-keys@2.0.0: {}
+
   lru-cache@11.2.7: {}
 
   lucide-react@0.487.0(react@19.1.2):
@@ -8491,6 +9445,14 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  merkletreejs@0.3.11:
+    dependencies:
+      bignumber.js: 9.3.1
+      buffer-reverse: 1.0.1
+      crypto-js: 4.2.0
+      treeify: 1.1.0
+      web3-utils: 1.10.4
+
   micro-ftch@0.3.1: {}
 
   micromatch@4.0.8:
@@ -8503,6 +9465,10 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -8569,6 +9535,13 @@ snapshots:
   node-releases@2.0.36: {}
 
   normalize-path@3.0.0: {}
+
+  normalize-url@6.1.0: {}
+
+  number-to-bn@1.7.0:
+    dependencies:
+      bn.js: 4.11.6
+      strip-hex-prefix: 1.0.0
 
   obj-multiplex@1.0.0:
     dependencies:
@@ -8684,11 +9657,11 @@ snapshots:
   ox@0.6.7(typescript@5.9.3)(zod@4.3.5):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.5)
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -8713,16 +9686,18 @@ snapshots:
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.2
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.5)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
+
+  p-cancelable@2.1.1: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -8823,10 +9798,14 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode@1.3.2: {}
 
   punycode@2.3.1: {}
 
@@ -8851,11 +9830,19 @@ snapshots:
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
 
+  querystring@0.2.0: {}
+
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
 
+  quick-lru@5.1.1: {}
+
   radix3@1.1.2: {}
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   react-clientside-effect@1.2.8(react@19.1.2):
     dependencies:
@@ -8969,6 +9956,8 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
+  resolve-alpn@1.2.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -8987,6 +9976,10 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
 
   reusify@1.1.0: {}
 
@@ -9279,6 +10272,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-hex-prefix@1.0.0:
+    dependencies:
+      is-hex-prefixed: 1.0.0
+
   strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(react@19.1.2):
@@ -9325,11 +10322,15 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  to-utf8@0.0.1: {}
+
   toidentifier@1.0.1: {}
 
   toposort@2.0.2: {}
 
   tr46@0.0.3: {}
+
+  treeify@1.1.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -9347,6 +10348,8 @@ snapshots:
   tslib@2.4.1: {}
 
   tslib@2.8.1: {}
+
+  tweetnacl@1.0.3: {}
 
   type-check@0.4.0:
     dependencies:
@@ -9396,6 +10399,8 @@ snapshots:
   uint8arrays@3.1.1:
     dependencies:
       multiformats: 9.9.0
+
+  ulid@2.4.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -9455,6 +10460,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url@0.11.0:
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+
   use-callback-ref@1.3.3(@types/react@19.1.12)(react@19.1.2):
     dependencies:
       react: 19.1.2
@@ -9482,6 +10492,8 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
     optional: true
+
+  utf8@3.0.0: {}
 
   util-deprecate@1.0.2: {}
 
@@ -9520,6 +10532,23 @@ snapshots:
       isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.6.7(typescript@5.9.3)(zod@4.3.5)
       ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.29.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5):
+    dependencies:
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.5)
+      isows: 1.0.6(ws@8.18.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      ox: 0.6.9(typescript@5.9.3)(zod@4.3.5)
+      ws: 8.18.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9579,6 +10608,17 @@ snapshots:
       - zod
 
   void-elements@3.1.0: {}
+
+  web3-utils@1.10.4:
+    dependencies:
+      '@ethereumjs/util': 8.1.0
+      bn.js: 5.2.3
+      ethereum-bloom-filters: 1.2.0
+      ethereum-cryptography: 2.2.1
+      ethjs-unit: 0.1.6
+      number-to-bn: 1.7.0
+      randombytes: 2.1.0
+      utf8: 3.0.0
 
   webextension-polyfill@0.10.0: {}
 
@@ -9652,6 +10692,11 @@ snapshots:
       utf-8-validate: 6.0.6
 
   ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.18.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6

--- a/examples/nextjs-iron-ramp/pnpm-lock.yaml
+++ b/examples/nextjs-iron-ramp/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@dynamic-labs/ethereum':
-        specifier: 4.52.2
-        version: 4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
+        specifier: 4.83.1
+        version: 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(@types/react@19.1.12)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
       '@dynamic-labs/sdk-react-core':
-        specifier: 4.52.2
-        version: 4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+        specifier: 4.83.1
+        version: 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(@types/react@19.1.12)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
       '@dynamic-labs/solana':
-        specifier: 4.52.2
-        version: 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
+        specifier: 4.83.1
+        version: 4.83.1(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
@@ -104,6 +104,9 @@ packages:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.0.0
 
+  '@ably/msgpack-js@0.4.1':
+    resolution: {integrity: sha512-Sjxj6SOr17hExAVrsycN7u6oV4PhZcK7Z2S8dM71CH/butgO47cSo/TL6FJPCXUyDAzKkOWjMUpJGyZkEpyu4Q==}
+
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
@@ -128,74 +131,76 @@ packages:
       '@dynamic-labs/wallet-connector-core': ^4.11.1
       viem: ^2.21.55
 
-  '@dynamic-labs-sdk/assert-package-version@0.1.2':
-    resolution: {integrity: sha512-riWzoNe0NoS0nSWX3pqQ0Tjt3OAIufI0LpuVR0SQwGA1Xr8BsZZs+RKb+cxDMtpyKE+ZaA+U3GEN+UXr2FYm/A==}
+  '@dynamic-labs-sdk/assert-package-version@0.26.9':
+    resolution: {integrity: sha512-hB9VvQOhE9j2EHAQfv7LCoLH8+DQXzYveHbsEK5dlU3BB4FoZTdJEU2SEH34q+g7Hyz3Nb+ioc5//jrr/tb39w==}
 
-  '@dynamic-labs-sdk/client@0.1.2':
-    resolution: {integrity: sha512-2GYWnVGwtD1xfpQunUvmISDlrsAnY7e9rjvebvuAtMy9st9PhZxomLxd0kj9v2sX4R+mxtD0vKuXMS0+p+tJ/Q==}
+  '@dynamic-labs-sdk/client@0.26.9':
+    resolution: {integrity: sha512-ubdqCkyiER9Ruc63E4IomvsOMMzSjGbFNeGnn3hIipzamPslrlAO9YTcU50qJEFioMneA2iJ00kbSBx+1VWHmw==}
 
-  '@dynamic-labs-wallet/browser-wallet-client@0.0.211':
-    resolution: {integrity: sha512-ZYtpKlisiDejEiD2oFIpcpkjFM0UMLTuRZ0gzEe+ybBn4e3g+Yt0XjKdcAPHvQVeIb94TgtZqLmxRW/lQz9hSQ==}
+  '@dynamic-labs-wallet/browser-wallet-client@0.0.325':
+    resolution: {integrity: sha512-niU6U2OPNg0aPMpQ+yqoTFYayKoRpLSxQg56mKHWM9RmbilGH5jHWXH3mEAVGS7u5YEAuZDnnCavBdWYSBsK5Q==}
 
-  '@dynamic-labs-wallet/browser-wallet-client@0.0.217':
-    resolution: {integrity: sha512-t9N1Ml94emoi4o2SxdMzBodlNCOaTsuedIGR2p3ABoF5GddErp3DocNoE5rgOC+U8GdAz9s0N/u9WMRkwHn2Xw==}
+  '@dynamic-labs-wallet/browser-wallet-client@0.0.337':
+    resolution: {integrity: sha512-0fZyXUfiZf/mPvvWl+kI4NqUAddWT18dWPRoM08xDUMZ8wGJmyWgD0MeqyJjHV92CV2by2cV+TRcEK3gnaf1sQ==}
 
-  '@dynamic-labs-wallet/browser@0.0.167':
-    resolution: {integrity: sha512-HDmUetnJ1iz6kGd5PB1kJzeLI7ZJmwxlJ1QGtUqSQHDdBkhLwaDPlccB2IviC5iPfU5PR/IQ1BYEqpoTWx2sBA==}
+  '@dynamic-labs-wallet/core@0.0.325':
+    resolution: {integrity: sha512-kWlCPMjHVBwiKyWUYrQrsgfTL2Mszsk1acjxJqfsWJucfgOxp432uO5XHGivosu3T1hfGNBNyKK6bChy3gL9Nw==}
+    peerDependencies:
+      '@dynamic-labs-wallet/forward-mpc-client': 0.5.5
 
-  '@dynamic-labs-wallet/core@0.0.167':
-    resolution: {integrity: sha512-jEHD/mDfnqx2/ML/MezY725uPPrKGsGoR3BaS1JNITGIitai1gPEgaEMqbXIhzId/m+Xieb8ZrLDiaYYJcXcyQ==}
+  '@dynamic-labs-wallet/core@0.0.337':
+    resolution: {integrity: sha512-csS/Xqx9kERTYLzt7BXHkaIBX8WIfUIDC3R0Yv6fweWdRL+6KX0A6lRUN1lajAF9/7d6XhxVzS/C3umS0qd7JQ==}
+    peerDependencies:
+      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0
 
-  '@dynamic-labs-wallet/core@0.0.211':
-    resolution: {integrity: sha512-PPLjOu55O4G204phWfPmpZNn4p+vcinZ8XvBvBcRl+uHhYxYIFg/Ma4C96ZrNB08iT5uxXxzNAWAg46ytO/GGA==}
+  '@dynamic-labs-wallet/forward-mpc-client@0.9.0':
+    resolution: {integrity: sha512-gotV/RnPTJmjosddbZU6L9Rgs6WEJRwNX/VO7v+0JKyyuzIZPvjA2wJLto9EVEiNMCKMES2a+VY39rEqcGNHCg==}
+    peerDependencies:
+      '@dynamic-labs-wallet/primitives': '>=0.0.336 || 0.0.1'
 
-  '@dynamic-labs-wallet/core@0.0.217':
-    resolution: {integrity: sha512-TzIyCYlcwFTOTHpr4phU7xQmkY+f76OTiPM/LZ9gW9m0Ji1ETokHfhv6nuLOQSbctGviTdrGxWF1Y1uhaLJEDQ==}
+  '@dynamic-labs-wallet/forward-mpc-shared@0.7.0':
+    resolution: {integrity: sha512-mN6zT5J8JbZxkOJxEjgGrjURybVn/t9DD+pWW5U4DRZH6Qakn5n1LIB4Lg4Y7OW9WwrlMH2IJ9RNgBW35RaF1A==}
+    peerDependencies:
+      '@dynamic-labs-wallet/primitives': '>=0.0.336 || 0.0.1'
 
-  '@dynamic-labs-wallet/forward-mpc-client@0.1.3':
-    resolution: {integrity: sha512-riZesfU41fMvetaxJ3bO48/9P8ikRPgoVJgWh8m8i0oRyYN7uUz+Iesp+52U12DCtcvSTXljxrKtrV3yqNAYRw==}
-
-  '@dynamic-labs-wallet/forward-mpc-shared@0.1.0':
-    resolution: {integrity: sha512-xRpMri4+ZuClonwf04RcnT/BCG8oA36ononD7s0MA5wSqd8kOuHjzNTSoM6lWnPiCmlpECyPARJ1CEO02Sfq9Q==}
-
-  '@dynamic-labs/assert-package-version@4.52.2':
-    resolution: {integrity: sha512-zpc0F5zUOBx0LcJ4iHZz9hSq4cl4rpCeNWzqQ/VrI3nEET+beU7AP/dYDFTIrD3DAE5KfpapK9IDt8ymkwVBmg==}
+  '@dynamic-labs-wallet/primitives@0.0.337':
+    resolution: {integrity: sha512-bhF0KBTQ+Ej/gZN/70fDd/ldy3Srqg/NgxzmKhUxMT31uY7OvCNblZ8r5gS6mjiNt+PhF8WmjOdEI5lCD6AjXQ==}
 
   '@dynamic-labs/assert-package-version@4.77.3':
     resolution: {integrity: sha512-MBMSg/eFrAgAnEhk0U1KdqN8zFny1vyO5HCsHRccyvkH5FuRFisnvT1Q0TKGWfPtB4SJePN9VSJDePW1MJGZIg==}
 
-  '@dynamic-labs/embedded-wallet-evm@4.52.2':
-    resolution: {integrity: sha512-nxinY85HRZCKwtlC3yL2e9PJp74tD6ZXB4THF9DL32QOySCiFuXvsftekcFzyrPN1J7nyAJBe++tnW785sxzcA==}
+  '@dynamic-labs/assert-package-version@4.83.1':
+    resolution: {integrity: sha512-wSpNfNxoaUVGGYQWGnvyiEuwoNr5YA9dTQZizvnEyCvI/HfipVsQRJjp63ysbPFmqLUFHvwYEDjcHE/+5/V62w==}
+
+  '@dynamic-labs/embedded-wallet-evm@4.83.1':
+    resolution: {integrity: sha512-7imCNZzKgOQOT0pFOnIx0OJWSDuYWC+v25RkHGDR5whOV+tyHd3Djtk32AjGcfMH3vQambkh6M1HgQY/XiSLOQ==}
     peerDependencies:
-      viem: ^2.28.4
+      viem: ^2.45.3
 
-  '@dynamic-labs/embedded-wallet-solana@4.52.2':
-    resolution: {integrity: sha512-5fEiTdPU2QaeNYxPQ1BvRcD+i9W2l1WVV7akS8WhCKdzi2B5V2l9/EP/+NC6EPHarPzgfz+omVYl9lsQmPIzVA==}
+  '@dynamic-labs/embedded-wallet-solana@4.83.1':
+    resolution: {integrity: sha512-3zabzOcUKR/NJhBx7EgjRXAD+pdl/77k2Yzqq57WC/Kau6Du2dRLJD98JbsSgQfqPqw5SWETnAd9TEw3nu/wpQ==}
 
-  '@dynamic-labs/embedded-wallet@4.52.2':
-    resolution: {integrity: sha512-oAp1ugcux6Ao2CyehhVXTYkiH9jrxBaCPmrSkp0kwJfitrGd92j6AkFgymI5gtNG/vLXjd2z/KcF+r9uNTedZQ==}
+  '@dynamic-labs/embedded-wallet@4.83.1':
+    resolution: {integrity: sha512-17K8Hr430y6JmpWKbqhuxJkw3bcsRVoIUSdLAra+SpW0UA4FuBv1McWeTJGuAAEDyfTs1rNxDTT/WcQxFnm9zA==}
 
-  '@dynamic-labs/ethereum-core@4.52.2':
-    resolution: {integrity: sha512-Ly3ILM5YXjs84g5UZfxkgbmodcr34IGI9mYiJQr7XGgMt/HhDOXySeDxo+rwkeWZxFctCFtbOZ1U46O4+XstBQ==}
+  '@dynamic-labs/ethereum-core@4.83.1':
+    resolution: {integrity: sha512-xPuxfgzBtj+KGjjOKN/2N3W171rOj9JFKfa92oDLTLv4jt9rfOPottUYgMGf4MGhqWnu8cbnbBlRr5DWukUqhA==}
     peerDependencies:
-      viem: ^2.28.4
+      viem: ^2.45.3
 
-  '@dynamic-labs/ethereum@4.52.2':
-    resolution: {integrity: sha512-cxrJciTzy7WOi8qGA+l3yD4dRYlwFuRt5UBxzHjty8g9q3rxlwwDja3aaC8XIfeUmEYv47soZ1st17dxwrO8yQ==}
+  '@dynamic-labs/ethereum@4.83.1':
+    resolution: {integrity: sha512-EEYrITNsffW/sv8s+Fnnet8yzfLUAv7Xmd9lEO/fTBjExJ2HTNdg+47OmNZMGthPfGR8z4gHye/vTdGnjvHSyA==}
     peerDependencies:
-      viem: ^2.28.4
+      viem: ^2.45.3
 
-  '@dynamic-labs/iconic@4.52.2':
-    resolution: {integrity: sha512-QHgiTGFcArcboYlOUknlB3X4sKY3S2MrBD+F3UGu5MxrPDUsE2Icloh0DQ1vWia7oND71hbTcf1NOpAKR1EBiQ==}
+  '@dynamic-labs/iconic@4.83.1':
+    resolution: {integrity: sha512-tYU1XYsI426LRnRp1ID1MybyXTitBXNTOZ+SKOWrNzqSnC503li6d4dm7pjuWAT0OZlpMlGw2bL0ZpV66Uojqw==}
     peerDependencies:
       react: '>=18.0.0 <20.0.0'
       react-dom: '>=18.0.0 <20.0.0'
 
-  '@dynamic-labs/locale@4.52.2':
-    resolution: {integrity: sha512-rsIOzdjIRfFYWxNUD++tEBhUE59cKbdQ3HPQhpjSGPFYXm8bQ35MUM4HW1FiiifZs0W+IgaDs0fsI+gtFwXvAw==}
-
-  '@dynamic-labs/logger@4.52.2':
-    resolution: {integrity: sha512-cFZzzBkZj0U9tBBgnQY9isNn0fz6VqnWJ1nTacuYrTSCyuFiIvPxYB8wffd9Tv4c0qOcxITm/dlcllvvipyEbw==}
+  '@dynamic-labs/locale@4.83.1':
+    resolution: {integrity: sha512-QlVqKyc9tVhisocfuPAlwKxfEebEfitE1F1j1TUGCsVrs4BukT7ZMhXvwE73z6umQAHILABXepwS0xjURRhLeg==}
 
   '@dynamic-labs/logger@4.77.3':
     resolution: {integrity: sha512-WnIceyRiW5Nb4QEbB5FdeH10k4q8DAnXTPf7Nvd8+c3rgzS1srdaQTdcgr8tbe1YP6LmIPm50hmUOJP6WErRYA==}
@@ -206,77 +211,77 @@ packages:
   '@dynamic-labs/message-transport@4.77.3':
     resolution: {integrity: sha512-SvqeyLz2xxsWbs8qnAwjaRMLttEefeOaqtUSdp2JNG4nPPt1+lkCpvWKgspeSF/96yKModdShhUQLutriFpMOg==}
 
-  '@dynamic-labs/multi-wallet@4.52.2':
-    resolution: {integrity: sha512-bmNn6JBfdDkVLDYJvcap5tWLtdNKyspRPKdAAghvyKnGH2M9Sefkpb/YjJmT7+U9YOTq3CJ7lhd2Ob5rA2mOOQ==}
+  '@dynamic-labs/multi-wallet@4.83.1':
+    resolution: {integrity: sha512-1zhme61u0a36EN7tdZo+IOPZmLij9owoQeUTB/VhcW7kB9HN0xOzM0wSqPEIv2/fstDR6H21GWyWP67qwI8FRw==}
 
-  '@dynamic-labs/rpc-providers@4.52.2':
-    resolution: {integrity: sha512-fdv0W+kzd4tnici0lDFWcNtg2mZHZBSrQdUsbrrBSpdENnzk3pqNkJP/keLMAwIYH397C3qbK4my0BoQzROPwQ==}
+  '@dynamic-labs/rpc-providers@4.83.1':
+    resolution: {integrity: sha512-KghsNAHBwoRoKN/FPuUfT1yQ+Kf7KhxuHcsH+XINfA90/zMLQrOKIsKeUyBboWWwCJrqCcGsG+lqUmxbCrBasw==}
 
-  '@dynamic-labs/sdk-api-core@0.0.764':
-    resolution: {integrity: sha512-79JptJTTClLc9qhioThtwMuzTHJ+mrj8sTEglb7Mcx3lJub9YbXqNdzS9mLRxZsr2et3aqqpzymXdUBzSEaMng==}
-
-  '@dynamic-labs/sdk-api-core@0.0.818':
-    resolution: {integrity: sha512-s0iq+kS15gbBk7HtFEVkuzHHUc8Xt0afA1el31+c8HBLIV0Bz1O4WaMTKdpvC/Rb5RS5GDCOmxeR6LvDzZBw+A==}
-
-  '@dynamic-labs/sdk-api-core@0.0.843':
-    resolution: {integrity: sha512-+4tcNWsKuPzt+suJax3jprwyI+w2gbEbSkzeuvI9/x1B9AuFPvIMxILoVqK9hEsrT57APQHnmTOkxSNk7aDgPA==}
+  '@dynamic-labs/sdk-api-core@0.0.900':
+    resolution: {integrity: sha512-4kb6IY75fFbTLwW24hN8ziVuxEeGAtsQpvXlKXA/XYrPKFFtJU6VQnuiKrKAerekIltdfMXEIqBJpcdPsmbszg==}
 
   '@dynamic-labs/sdk-api-core@0.0.927':
     resolution: {integrity: sha512-jL0XRN9GzKeN2wcppD8Ixt2Q7VtkNSbBv6up6el8vutsiQ8ZxA/eX/Wb1ysw8TXiIcDUl2p0afyWwkSxIj+8rw==}
 
-  '@dynamic-labs/sdk-react-core@4.52.2':
-    resolution: {integrity: sha512-Xk2f6UcIOY3QbXRlwhizHF6Gd+PRMjuIuW4DbKIMfrz8WGKyKF/Qh7AQTJ3ReKYm1KevCbCNLsn0c14/p3F9sA==}
+  '@dynamic-labs/sdk-api-core@0.0.958':
+    resolution: {integrity: sha512-jbDSjxWi69Nb5ZRmMrt+tV1gqGoPflvZnw7Qlpmbxbfguqx8KBzvDdDphMJ5jW2YCEmD8dRw2qizOrnN1gjIxw==}
+
+  '@dynamic-labs/sdk-api-core@0.0.964':
+    resolution: {integrity: sha512-U7PdyUQXdvToWCoysBIURYDMy+3XTnGZsdruv1Bl1LKwXHNbR8jGwIt6ibf0vbp1lQga6fc4DPnlAjbtUHaPIA==}
+
+  '@dynamic-labs/sdk-react-core@4.83.1':
+    resolution: {integrity: sha512-qOrCn5UURTzZeQzs2kypbG9GcryASPXs+KYLNRSPeSwjrgy7GzoYsfucSibaJ9NFLwO/h6X60lXW3VXMowS8EA==}
     peerDependencies:
       react: '>=18.0.0 <20.0.0'
       react-dom: '>=18.0.0 <20.0.0'
 
-  '@dynamic-labs/solana-core@4.52.2':
-    resolution: {integrity: sha512-BDenb4mDIR4naQRZ2fg9XpKZEvyZujinq/TkfRsAzvoWQkOjLXY3SwxCtUhTEBh48VF+rTFVd8+SAPpoMpUntQ==}
+  '@dynamic-labs/solana-core@4.83.1':
+    resolution: {integrity: sha512-j2Upn13oq8z/biAQWAeLocrKqaVeA1yVFWnxSzB0DKPsyKs944LgdFXo2IOVwycegvhejMfGezMVloaO5AgVkg==}
 
-  '@dynamic-labs/solana@4.52.2':
-    resolution: {integrity: sha512-Ni24LTAyHmWeeftmM1gEGQDyuSsgM6QLvB/Ux6DG5s+hIyiXBqa6+n5jTww6KHKn49qZ8LKTdt2Mn658hVZNjA==}
+  '@dynamic-labs/solana@4.83.1':
+    resolution: {integrity: sha512-F5O1hKD8NCvYlchnbsXG7WLfNSQw6NcYkGK3xfcSMuYDRRCeU0ONQyGShzMG2tEXJOfeNL3Q0eksAM+uc5kv0Q==}
 
-  '@dynamic-labs/store@4.52.2':
-    resolution: {integrity: sha512-Kt+DqcP8QaILXTX/1TjwyQEDupU+SAV5ZL92CYsuGqqDYftOC21nBlIFz7fEYx4eUn/v+w+iEvJ5qd8Hbm7OlA==}
+  '@dynamic-labs/store@4.83.1':
+    resolution: {integrity: sha512-npxA1/CR8eHAUGzUwKvs7+y8qkuoaqDFIBT0qcX+1jmsXOy2PwAfAr063O9WVjkPPtTTQ6E1X/9LNPAoGmNnkQ==}
 
-  '@dynamic-labs/sui-core@4.52.2':
-    resolution: {integrity: sha512-eFuIKWKRH7brm/+66nVk8g2ZnzsdwI6K5EEd4Bo6WGvvHCMKY8hmUr6zMQgU4rWCa+VW3DmwXI9sCKt4FOUkWQ==}
-
-  '@dynamic-labs/types@4.52.2':
-    resolution: {integrity: sha512-DIkd7tfvZAObPLMlwEbZLwL5oZDyR6EvjMzEHpje53aoSqOEhYohKDSzIQTVy7dmCQjcGt8fCnQmQxDPeyKZhQ==}
+  '@dynamic-labs/sui-core@4.83.1':
+    resolution: {integrity: sha512-KNfwj3X5NaiW05cmy4jwwZaIssOOAwnuXUbp/4D00QA0LSjILViLlJHoi1RybMrB1R1r4ZA+erKGydwhZ1YE3w==}
 
   '@dynamic-labs/types@4.77.3':
     resolution: {integrity: sha512-tP45k6blfuuWDt8Vua+ZcvxM3DxkiieIg7vSt5aXUgBbaFFygnz98d1u+n1PD9np2NqDWyCUjMJE71Uk2HLrFg==}
 
-  '@dynamic-labs/utils@4.52.2':
-    resolution: {integrity: sha512-3rvKPjjc7zvC8E30E5UYSfx0ZBjNNKqziJDw/N0p5KvbIWech4y5xHkaNmW6vxWTRT89trwtbtyrPJuRoK3rsg==}
+  '@dynamic-labs/types@4.83.1':
+    resolution: {integrity: sha512-lwNz57iJLk/bySkGVxeYIbWZvmb18s9yD2QbXQguyChu6V4/PdoRH4DGBr9xxOMY06zzSVSN3g2ctrsepv4atg==}
 
   '@dynamic-labs/utils@4.77.3':
     resolution: {integrity: sha512-UeSy8YYvbKwMbCmVkcxrVb9f7k0Oe5MYn2R6k1+phsgG4Zfst8IyN/d4KgKDSBZaeKnYN5z+ZekgBLJzeRtA5g==}
 
-  '@dynamic-labs/waas-evm@4.52.2':
-    resolution: {integrity: sha512-rWn+1aFWK0a/95wEiyg1qyusTJvxC6VKiIdITNsXeLZkBXkMy8HFPHeD5lBjW8mVOn5HRcAGHLYAYfpINSncfw==}
+  '@dynamic-labs/utils@4.83.1':
+    resolution: {integrity: sha512-6PgT0Xr8IQUn4xx3fBn2XEcyA9NAnR/BSVEsOb/+KgFRhx7bmKkwC3Bh1ooCXpr9P/osutT9Yy+Eb/3rg182CA==}
 
-  '@dynamic-labs/waas-svm@4.52.2':
-    resolution: {integrity: sha512-6B/mRgwCJIu8Ir00EYHXapwTQGR/ahQvbfYIkMqfOtl6wZDoBd1f4zJO3GLPnYcErG7DKdYVW2hY6/bR/0KL2w==}
+  '@dynamic-labs/waas-evm@4.83.1':
+    resolution: {integrity: sha512-sCfnGEWRR9KlmNuLRYrzxsRq8WsEG0jEd06RTdyQWYbsMWbb8781iXEzAfMRDEeTRxcbxbH5tB1M4cCs11uiqg==}
 
-  '@dynamic-labs/waas@4.52.2':
-    resolution: {integrity: sha512-qreXLXnCxdVKItdWrbmxfbMV0ybRqFS+qDUDueXmze3pR2+pZgCw1yhAhCayQ9nQQFFJUZxzWqQhAXszJXxPHQ==}
+  '@dynamic-labs/waas-svm@4.83.1':
+    resolution: {integrity: sha512-SvOTohXOKCTd/lvqRODio4IHw7yGOPLxnk8tGo8zavXs2qzJEJTaLUPBwzJ5rqYHJ65qmwhPjTfpJXe/OfkLkw==}
 
-  '@dynamic-labs/wallet-book@4.52.2':
-    resolution: {integrity: sha512-7jOwiUOfbYj/Ih9EQ1px851KJzxalZPWCrZBTB1Wu4NKlhKRwjNQCwbusteIm6z2AkSVndpmXR9cqhfVa99rxQ==}
+  '@dynamic-labs/waas@4.83.1':
+    resolution: {integrity: sha512-um/GNBEf+wvvP3RPh2hrj6xI7JiweHdSeShUEnwVSn6MjDwMWynjroxRIK5l2Jl8KMiUQgU5FdPVfP3PUdD+Dw==}
+
+  '@dynamic-labs/wallet-book@4.83.1':
+    resolution: {integrity: sha512-FNCQsS8U1l2SgvbZAESJcBcVcVJ7EeQrazNiEIKze4gcAwlJXDMoa/ThbN/dUOGaY1smM0A8TOKiBER96+t7OA==}
     peerDependencies:
       react: '>=18.0.0 <20.0.0'
       react-dom: '>=18.0.0 <20.0.0'
 
-  '@dynamic-labs/wallet-connect@4.52.2':
-    resolution: {integrity: sha512-h4nSQdkfRnT82wHPsv1gFk3V7wLmL0dMRtglkhri3cghIHwSfCaW0AYLArhojEQ68gitnvS42oWfeC+QE0waWg==}
+  '@dynamic-labs/wallet-connect@4.83.1':
+    resolution: {integrity: sha512-1Yioj7KEgNB9KH+eSdPxoHHzhNNuezIdbVFX851kdc4moGywdcGO3trsLMqKQzcjbg70B4RwDyz/0PyIp27auw==}
 
-  '@dynamic-labs/wallet-connector-core@4.52.2':
-    resolution: {integrity: sha512-bAINAsC4Ydz7/UjctOrRSNZG8xhg7YZQkMLnz0uX5t/hB71UiFpnU890bJQJg95YjYHsHmHw1PUBCCI6sONnHw==}
+  '@dynamic-labs/wallet-connector-core@4.83.1':
+    resolution: {integrity: sha512-lYAuLgMB8aKqT+M+vftUslIy5YlArs4LxcwCHZgQNoly1UB9CEjGSJFQBQmZQIrmz7TB+8H8V11uHhGu/Ow3IQ==}
 
-  '@dynamic-labs/webauthn@4.52.2':
-    resolution: {integrity: sha512-RytiwqsCWB8TiYFr8Xb3cj7JmumUMyz2wz49phK/wA5WS2F/t6OUt4cW/QMBEfVhgvq1YOIn7fKuFFlsTeDv4A==}
+  '@dynamic-labs/webauthn@4.83.1':
+    resolution: {integrity: sha512-8d4OQK4D/7Hdn4x2cAWC5uiXW1j1ZFmDsm5Hg3QkXhuBOGO7zqleT2VhPfm0RXcdG7p6Po0RtuFFWmv6jTvWgw==}
 
   '@ecies/ciphers@0.2.6':
     resolution: {integrity: sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==}
@@ -785,15 +790,18 @@ packages:
     resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
     engines: {node: '>= 18'}
 
-  '@mysten/bcs@1.5.0':
-    resolution: {integrity: sha512-v39dm5oNfKYMAf2CVI+L0OaJiG9RVXsjqPM4BwTKcHNCZOvr35IIewGtXtWXsI67SQU2TRq8lhQzeibdiC/CNg==}
+  '@mysten/bcs@1.9.2':
+    resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
 
-  '@mysten/sui@1.24.0':
-    resolution: {integrity: sha512-lmJJLM7eMrxM6Qpr6cdLr07UBXlxCM7SJjfcDO7NGrqZTx7/3TD2QhhRpDx0fS2tODxrNwQxCoHPApLVPjokIA==}
+  '@mysten/sui@1.45.2':
+    resolution: {integrity: sha512-gftf7fNpFSiXyfXpbtP2afVEnhc7p2m/MEYc/SO5pov92dacGKOpQIF7etZsGDI1Wvhv+dpph+ulRNpnYSs7Bg==}
     engines: {node: '>=18'}
 
-  '@mysten/wallet-standard@0.13.29':
-    resolution: {integrity: sha512-NR9I3HprticwT3HRPQ36VojV5Gjp+S/iJYdib3qLVrSiCOQjoilmYzA53pDu/rFDSrljskgV/0fAj9ynF9nVFg==}
+  '@mysten/utils@0.2.0':
+    resolution: {integrity: sha512-CM6kJcJHX365cK6aXfFRLBiuyXc5WSBHQ43t94jqlCAIRw8umgNcTb5EnEA9n31wPAQgLDGgbG/rCUISCTJ66w==}
+
+  '@mysten/wallet-standard@0.19.9':
+    resolution: {integrity: sha512-jHFt+62os7x7y+4ZVMLck8WSanEO9b8deCD+VApUQkdAHA99TuxbREaujQTjnGQN5DaGEz8wQgeBPqxRY/vKQA==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -894,6 +902,10 @@ packages:
     resolution: {integrity: sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@1.9.4':
+    resolution: {integrity: sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
@@ -952,6 +964,15 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
+
+  '@protobuf-ts/grpcweb-transport@2.11.1':
+    resolution: {integrity: sha512-1W4utDdvOB+RHMFQ0soL4JdnxjXV+ddeGIUg08DvZrA8Ms6k5NN6GBFU2oHZdTOcJVpPrDJ02RJlqtaoCMNBtw==}
+
+  '@protobuf-ts/runtime-rpc@2.11.1':
+    resolution: {integrity: sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==}
+
+  '@protobuf-ts/runtime@2.11.1':
+    resolution: {integrity: sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1310,6 +1331,10 @@ packages:
     resolution: {integrity: sha512-q6y8MkoV8V8jB4zzp18Uyj2I7oFp2/ONL8c3j8uT06AOWu3cIChc1au71QYHrP2b+xDapkGTiv+9lX7xkTlAsA==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
@@ -1389,8 +1414,8 @@ packages:
     peerDependencies:
       '@solana/web3.js': ^1.95.3
 
-  '@solana/spl-token@0.4.12':
-    resolution: {integrity: sha512-K6CxzSoO1vC+WBys25zlSDaW0w4UFZO/IvEZquEI35A/PjqXNQHeVigmDCZYEJfESvYarKwsr8tYr/29lPtvaw==}
+  '@solana/spl-token@0.4.14':
+    resolution: {integrity: sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.95.5
@@ -1403,6 +1428,10 @@ packages:
 
   '@swc/helpers@0.5.20':
     resolution: {integrity: sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==}
+
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
 
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
@@ -1564,6 +1593,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/cacheable-request@6.0.3':
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -1573,11 +1605,17 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/keyv@3.1.4':
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
@@ -1598,6 +1636,9 @@ packages:
 
   '@types/react@19.1.12':
     resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
+
+  '@types/responselike@1.0.3':
+    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1795,8 +1836,8 @@ packages:
     resolution: {integrity: sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==}
     engines: {node: '>=16'}
 
-  '@wallet-standard/core@1.1.0':
-    resolution: {integrity: sha512-v2W5q/NlX1qkn2q/JOXQT//pOAdrhz7+nOcO2uiH9+a0uvreL+sdWWqkhFmMcX+HEBjaibdOQMUoIfDhOGX4XA==}
+  '@wallet-standard/core@1.1.1':
+    resolution: {integrity: sha512-5Xmjc6+Oe0hcPfVc5n8F77NVLwx1JVAoCVgQpLyv/43/bhtIif+Gx3WUrDlaSDoM8i2kA2xd6YoFbHCxs+e0zA==}
     engines: {node: '>=16'}
 
   '@wallet-standard/errors@0.1.1':
@@ -1935,6 +1976,18 @@ packages:
       zod:
         optional: true
 
+  ably@2.17.1:
+    resolution: {integrity: sha512-70yfXHoM7JtJD/8FCtPD1gkWW0f+AJqbJp0PsqDAqiyxFB8cPFY+FuKHgNTYb8eRHKXq8hT1xiDphUcY0+GHnA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1963,9 +2016,6 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-
-  argon2id@1.0.1:
-    resolution: {integrity: sha512-rsiD3lX+0L0CsiZARp3bf9EGxprtuWAT7PpiJd+Fk53URV0/USOQkBIP1dLTV8t6aui0ECbymQ9W9YCcTd6XgA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2039,11 +2089,11 @@ packages:
     resolution: {integrity: sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==}
     engines: {node: '>=4'}
 
-  axios@1.13.2:
-    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
-  axios@1.9.0:
-    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2064,6 +2114,10 @@ packages:
 
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
+
+  base64-js@1.0.2:
+    resolution: {integrity: sha512-ZXBDPMt/v/8fsIqn+Z5VwrhdR6jVka0bYobHdGia0Nxi7BJ9i/Uvml3AocHIBtIIBhZjBw5MR0aR4ROs/8+SNg==}
+    engines: {node: '>= 0.4'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2091,6 +2145,9 @@ packages:
 
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
+
+  bops@1.0.1:
+    resolution: {integrity: sha512-qCMBuZKP36tELrrgXpAfM+gHzqa0nLsWZ+L37ncsb8txYlnAoxOPpVp+g7fK0sGkMXfA0wl8uQkESqw3v4HNag==}
 
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
@@ -2132,6 +2189,14 @@ packages:
   bufferutil@4.1.0:
     resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
     engines: {node: '>=6.14.2'}
+
+  cacheable-lookup@5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2176,6 +2241,9 @@ packages:
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
   clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
@@ -2298,12 +2366,20 @@ packages:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   deepmerge@2.2.1:
     resolution: {integrity: sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==}
     engines: {node: '>=0.10.0'}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -2324,9 +2400,9 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   derive-valtio@0.1.0:
     resolution: {integrity: sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==}
@@ -2716,6 +2792,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -2742,6 +2822,10 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
 
   gql.tada@1.9.1:
     resolution: {integrity: sha512-Ijtwgw08aE7l06wK5oj5Msgpk9SUe5FSVcuxU5dHyefdM7fDqLQpA76yHBoq8lPB3MNSir8tznodDknHkm2Z/w==}
@@ -2796,9 +2880,12 @@ packages:
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
 
-  http-errors@2.0.0:
-    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
-    engines: {node: '>= 0.8'}
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http2-wrapper@1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -3151,6 +3238,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
+
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
@@ -3185,6 +3276,14 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -3269,6 +3368,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+
   obj-multiplex@1.0.0:
     resolution: {integrity: sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA==}
 
@@ -3327,6 +3430,14 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  ox@0.12.4:
+    resolution: {integrity: sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.14.7:
     resolution: {integrity: sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==}
     peerDependencies:
@@ -3358,6 +3469,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -3466,11 +3581,15 @@ packages:
   proxy-compare@2.6.0:
     resolution: {integrity: sha512-8xuCeM3l8yqdmbPoYeLbrAXCBWu19XEYc5/F28f5qOaoAIMyfmBUkl5axiK+x9olUvRlcekvnm98AP9RDngOIw==}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode@1.3.2:
+    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3490,11 +3609,20 @@ packages:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
 
+  querystring@0.2.0:
+    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -3606,6 +3734,9 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3622,6 +3753,9 @@ packages:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -3681,9 +3815,6 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
-
-  setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sha256-uint8array@0.10.7:
     resolution: {integrity: sha512-1Q6JQU4tX9NqsDGodej6pkrUVQVNapLZnvkwIhddH/JqzBZF1fSaxSWNY6sziXBE8aEa2twtGkXUrwzGeZCMpQ==}
@@ -3748,10 +3879,6 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
-
-  statuses@2.0.1:
-    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
-    engines: {node: '>= 0.8'}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3878,9 +4005,8 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
+  to-utf8@0.0.1:
+    resolution: {integrity: sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ==}
 
   toposort@2.0.2:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
@@ -3942,6 +4068,10 @@ packages:
 
   uint8arrays@3.1.1:
     resolution: {integrity: sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==}
+
+  ulid@2.4.0:
+    resolution: {integrity: sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==}
+    hasBin: true
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -4027,6 +4157,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url@0.11.0:
+    resolution: {integrity: sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -4072,14 +4205,21 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  valibot@0.36.0:
-    resolution: {integrity: sha512-CjF1XN4sUce8sBK9TixrDqFM7RwNkuXdJu174/AwmQUB62QbCQADg5lLe8ldBalFgtj1uKj+pKwDJiNo4Mn+eQ==}
+  valibot@1.3.1:
+    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   valtio@1.13.2:
     resolution: {integrity: sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==}
@@ -4101,16 +4241,16 @@ packages:
       typescript:
         optional: true
 
-  viem@2.29.0:
-    resolution: {integrity: sha512-N6GeIuuay/spDyw+5FbSuNIkVN0da+jGOjdlC0bdatIN+N0jtOf9Zfj0pbXgpIJGwnM9ocxzTRt0HZVbHBdL2Q==}
+  viem@2.31.0:
+    resolution: {integrity: sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  viem@2.31.0:
-    resolution: {integrity: sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA==}
+  viem@2.46.3:
+    resolution: {integrity: sha512-2LJS+Hyh2sYjHXQtzfv1kU9pZx9dxFzvoU/ZKIcn0FNtOU0HQuIICuYdWtUDFHaGXbAdVo8J1eCvmjkL9JVGwg==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -4187,18 +4327,6 @@ packages:
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.1:
-    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4307,6 +4435,10 @@ snapshots:
       graphql: 16.13.2
       typescript: 5.9.3
 
+  '@ably/msgpack-js@0.4.1':
+    dependencies:
+      bops: 1.0.1
+
   '@adraffy/ens-normalize@1.11.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
@@ -4346,11 +4478,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@dynamic-labs-connectors/base-account-evm@4.4.2(@dynamic-labs/ethereum-core@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(@dynamic-labs/wallet-connector-core@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(@types/react@19.1.12)(bufferutil@4.1.0)(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
+  '@dynamic-labs-connectors/base-account-evm@4.4.2(@dynamic-labs/ethereum-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(@dynamic-labs/wallet-connector-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6))(@types/react@19.1.12)(bufferutil@4.1.0)(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
     dependencies:
       '@base-org/account': 1.1.1(@types/react@19.1.12)(bufferutil@4.1.0)(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(zod@4.3.5)
-      '@dynamic-labs/ethereum-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/ethereum-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
       viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
     transitivePeerDependencies:
       - '@types/react'
@@ -4362,145 +4494,116 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@dynamic-labs-sdk/assert-package-version@0.1.2': {}
+  '@dynamic-labs-sdk/assert-package-version@0.26.9': {}
 
-  '@dynamic-labs-sdk/client@0.1.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@dynamic-labs-sdk/client@0.26.9(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
     dependencies:
-      '@dynamic-labs-sdk/assert-package-version': 0.1.2
-      '@dynamic-labs-wallet/browser-wallet-client': 0.0.211(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/sdk-api-core': 0.0.843
+      '@dynamic-labs-sdk/assert-package-version': 0.26.9
+      '@dynamic-labs-wallet/browser-wallet-client': 0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@dynamic-labs/sdk-api-core': 0.0.958
       '@simplewebauthn/browser': 13.1.0
+      ably: 2.17.1(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
       buffer: 6.0.3
       eventemitter3: 5.0.1
       zod: 4.0.5
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/forward-mpc-client'
       - bufferutil
       - debug
+      - react
+      - react-dom
       - utf-8-validate
 
-  '@dynamic-labs-wallet/browser-wallet-client@0.0.211(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@dynamic-labs-wallet/browser-wallet-client@0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@dynamic-labs-wallet/core': 0.0.211(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@dynamic-labs-wallet/core': 0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@dynamic-labs/logger': 4.83.1
       '@dynamic-labs/message-transport': 4.77.3
-      uuid: 11.1.0
     transitivePeerDependencies:
-      - bufferutil
+      - '@dynamic-labs-wallet/forward-mpc-client'
       - debug
-      - utf-8-validate
 
-  '@dynamic-labs-wallet/browser-wallet-client@0.0.217(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@dynamic-labs-wallet/browser-wallet-client@0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@dynamic-labs-wallet/core': 0.0.217(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@dynamic-labs-wallet/core': 0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@dynamic-labs/logger': 4.83.1
       '@dynamic-labs/message-transport': 4.77.3
-      uuid: 11.1.0
     transitivePeerDependencies:
-      - bufferutil
+      - '@dynamic-labs-wallet/forward-mpc-client'
       - debug
-      - utf-8-validate
 
-  '@dynamic-labs-wallet/browser@0.0.167':
+  '@dynamic-labs-wallet/core@0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@dynamic-labs-wallet/core': 0.0.167
-      '@dynamic-labs/logger': 4.83.1
-      '@dynamic-labs/sdk-api-core': 0.0.764
-      '@noble/hashes': 1.7.1
-      argon2id: 1.0.1
-      axios: 1.9.0
-      http-errors: 2.0.0
-      semver: 7.7.4
+      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@dynamic-labs/sdk-api-core': 0.0.900
+      axios: 1.15.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
 
-  '@dynamic-labs-wallet/core@0.0.167':
+  '@dynamic-labs-wallet/core@0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@dynamic-labs/sdk-api-core': 0.0.764
-      axios: 1.9.0
+      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@dynamic-labs-wallet/primitives': 0.0.337
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      axios: 1.15.2
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
 
-  '@dynamic-labs-wallet/core@0.0.211(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
-      '@dynamic-labs-wallet/forward-mpc-client': 0.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/logger': 4.83.1
-      '@dynamic-labs/sdk-api-core': 0.0.818
-      axios: 1.13.2
-      http-errors: 2.0.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - utf-8-validate
-
-  '@dynamic-labs-wallet/core@0.0.217(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@dynamic-labs-wallet/forward-mpc-client': 0.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/logger': 4.83.1
-      '@dynamic-labs/sdk-api-core': 0.0.818
-      axios: 1.13.2
-      http-errors: 2.0.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - utf-8-validate
-
-  '@dynamic-labs-wallet/forward-mpc-client@0.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@dynamic-labs-wallet/core': 0.0.167
-      '@dynamic-labs-wallet/forward-mpc-shared': 0.1.0
+      '@dynamic-labs-wallet/forward-mpc-shared': 0.7.0(@dynamic-labs-wallet/primitives@0.0.337)
+      '@dynamic-labs-wallet/primitives': 0.0.337
       '@evervault/wasm-attestation-bindings': 0.3.1
       '@noble/hashes': 2.0.1
-      '@noble/post-quantum': 0.5.4
       eventemitter3: 5.0.1
       fp-ts: 2.16.11
+      isows: 1.0.7(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
-      - debug
       - utf-8-validate
 
-  '@dynamic-labs-wallet/forward-mpc-shared@0.1.0':
+  '@dynamic-labs-wallet/forward-mpc-shared@0.7.0(@dynamic-labs-wallet/primitives@0.0.337)':
     dependencies:
-      '@dynamic-labs-wallet/browser': 0.0.167
-      '@dynamic-labs-wallet/core': 0.0.167
+      '@dynamic-labs-wallet/primitives': 0.0.337
       '@noble/ciphers': 0.4.1
       '@noble/hashes': 2.0.1
       '@noble/post-quantum': 0.5.4
       fp-ts: 2.16.11
       io-ts: 2.2.22(fp-ts@2.16.11)
-    transitivePeerDependencies:
-      - debug
 
-  '@dynamic-labs/assert-package-version@4.52.2':
-    dependencies:
-      '@dynamic-labs/logger': 4.52.2
+  '@dynamic-labs-wallet/primitives@0.0.337': {}
 
   '@dynamic-labs/assert-package-version@4.77.3':
     dependencies:
       '@dynamic-labs/logger': 4.77.3
 
-  '@dynamic-labs/embedded-wallet-evm@4.52.2(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
+  '@dynamic-labs/assert-package-version@4.83.1':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/embedded-wallet': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/ethereum-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/webauthn': 4.52.2
+      '@dynamic-labs/logger': 4.83.1
+
+  '@dynamic-labs/embedded-wallet-evm@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/embedded-wallet': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs/ethereum-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs/webauthn': 4.83.1
       '@turnkey/api-key-stamper': 0.4.7
       '@turnkey/iframe-stamper': 2.5.0
       '@turnkey/viem': 0.13.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
       '@turnkey/webauthn-stamper': 0.5.1
       viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
       - bufferutil
+      - debug
       - encoding
       - react
       - react-dom
@@ -4508,25 +4611,27 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@dynamic-labs/embedded-wallet-solana@4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)':
+  '@dynamic-labs/embedded-wallet-solana@4.83.1(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)':
     dependencies:
-      '@dynamic-labs-sdk/client': 0.1.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/embedded-wallet': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/rpc-providers': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/solana-core': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/webauthn': 4.52.2
+      '@dynamic-labs-sdk/client': 0.26.9(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/embedded-wallet': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/solana-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs/webauthn': 4.83.1
       '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@turnkey/iframe-stamper': 2.5.0
       '@turnkey/solana': 1.0.42(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
       '@turnkey/webauthn-stamper': 0.5.1
-      viem: 2.29.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+      viem: 2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/forward-mpc-client'
+      - '@dynamic-labs-wallet/primitives'
       - bufferutil
       - debug
       - encoding
@@ -4537,53 +4642,61 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@dynamic-labs/embedded-wallet@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
+  '@dynamic-labs/embedded-wallet@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/webauthn': 4.52.2
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs/webauthn': 4.83.1
       '@turnkey/api-key-stamper': 0.4.7
       '@turnkey/http': 3.10.0
       '@turnkey/iframe-stamper': 2.5.0
       '@turnkey/webauthn-stamper': 0.5.1
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
+      - bufferutil
+      - debug
       - encoding
       - react
       - react-dom
+      - utf-8-validate
 
-  '@dynamic-labs/ethereum-core@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
+  '@dynamic-labs/ethereum-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/rpc-providers': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
       viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
+      - bufferutil
+      - debug
       - react
       - react-dom
+      - utf-8-validate
 
-  '@dynamic-labs/ethereum@4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
+  '@dynamic-labs/ethereum@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(@types/react@19.1.12)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
     dependencies:
       '@coinbase/wallet-sdk': 4.3.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
-      '@dynamic-labs-connectors/base-account-evm': 4.4.2(@dynamic-labs/ethereum-core@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(@dynamic-labs/wallet-connector-core@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(@types/react@19.1.12)(bufferutil@4.1.0)(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/embedded-wallet-evm': 4.52.2(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
-      '@dynamic-labs/ethereum-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/rpc-providers': 4.52.2
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/waas-evm': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs-connectors/base-account-evm': 4.4.2(@dynamic-labs/ethereum-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(@dynamic-labs/wallet-connector-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6))(@types/react@19.1.12)(bufferutil@4.1.0)(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/embedded-wallet-evm': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
+      '@dynamic-labs/ethereum-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/waas-evm': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
       '@metamask/sdk': 0.33.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@walletconnect/ethereum-provider': 2.21.5(@types/react@19.1.12)(bufferutil@4.1.0)(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
       buffer: 6.0.3
@@ -4598,6 +4711,7 @@ snapshots:
       - '@azure/storage-blob'
       - '@capacitor/preferences'
       - '@deno/kv'
+      - '@dynamic-labs-wallet/primitives'
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
       - '@netlify/blobs'
@@ -4625,27 +4739,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@dynamic-labs/iconic@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
+  '@dynamic-labs/iconic@4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/logger': 4.52.2
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
       react: 19.1.2
       react-dom: 19.1.2(react@19.1.2)
       sharp: 0.33.5
+      url: 0.11.0
 
-  '@dynamic-labs/locale@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
+  '@dynamic-labs/locale@4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
+      '@dynamic-labs/assert-package-version': 4.83.1
       i18next: 23.4.6
       react-i18next: 13.5.0(i18next@23.4.6)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
     transitivePeerDependencies:
       - react
       - react-dom
       - react-native
-
-  '@dynamic-labs/logger@4.52.2':
-    dependencies:
-      eventemitter3: 5.0.1
 
   '@dynamic-labs/logger@4.77.3':
     dependencies:
@@ -4663,48 +4774,54 @@ snapshots:
       '@vue/reactivity': 3.5.31
       eventemitter3: 5.0.1
 
-  '@dynamic-labs/multi-wallet@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
+  '@dynamic-labs/multi-wallet@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/rpc-providers': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
       tslib: 2.4.1
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
+      - bufferutil
+      - debug
       - react
       - react-dom
+      - utf-8-validate
 
-  '@dynamic-labs/rpc-providers@4.52.2':
+  '@dynamic-labs/rpc-providers@4.83.1':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/types': 4.52.2
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/types': 4.83.1
 
-  '@dynamic-labs/sdk-api-core@0.0.764': {}
-
-  '@dynamic-labs/sdk-api-core@0.0.818': {}
-
-  '@dynamic-labs/sdk-api-core@0.0.843': {}
+  '@dynamic-labs/sdk-api-core@0.0.900': {}
 
   '@dynamic-labs/sdk-api-core@0.0.927': {}
 
-  '@dynamic-labs/sdk-react-core@4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
+  '@dynamic-labs/sdk-api-core@0.0.958': {}
+
+  '@dynamic-labs/sdk-api-core@0.0.964': {}
+
+  '@dynamic-labs/sdk-react-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(@types/react@19.1.12)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
     dependencies:
-      '@dynamic-labs-sdk/client': 0.1.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/iconic': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/locale': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/multi-wallet': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/rpc-providers': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/store': 4.52.2
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs-sdk/client': 0.26.9(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs-wallet/browser-wallet-client': 0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/iconic': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/locale': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/multi-wallet': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/store': 4.83.1
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
       '@hcaptcha/react-hcaptcha': 1.4.4(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
       '@thumbmarkjs/thumbmarkjs': 0.16.0
       bs58: 5.0.0
@@ -4720,26 +4837,29 @@ snapshots:
       react-international-phone: 4.5.0(react@19.1.2)
       yup: 0.32.11
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
       - '@types/react'
       - bufferutil
       - debug
       - react-native
       - utf-8-validate
 
-  '@dynamic-labs/solana-core@4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@dynamic-labs/solana-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/rpc-providers': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@solana/spl-token': 0.4.12(@solana/web3.js@1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       eventemitter3: 5.0.1
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
       - bufferutil
+      - debug
       - encoding
       - fastestsmallesttextencoderdecoder
       - react
@@ -4747,20 +4867,20 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@dynamic-labs/solana@4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
+  '@dynamic-labs/solana@4.83.1(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/embedded-wallet-solana': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/rpc-providers': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/solana-core': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/waas-svm': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connect': 4.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/embedded-wallet-solana': 4.83.1(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/solana-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/waas-svm': 4.83.1(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connect': 4.83.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@wallet-standard/app': 1.0.1
       '@wallet-standard/base': 1.0.1
@@ -4781,6 +4901,8 @@ snapshots:
       - '@azure/storage-blob'
       - '@capacitor/preferences'
       - '@deno/kv'
+      - '@dynamic-labs-wallet/forward-mpc-client'
+      - '@dynamic-labs-wallet/primitives'
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
       - '@netlify/blobs'
@@ -4805,50 +4927,44 @@ snapshots:
       - viem
       - zod
 
-  '@dynamic-labs/store@4.52.2':
+  '@dynamic-labs/store@4.83.1':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/logger': 4.52.2
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
 
-  '@dynamic-labs/sui-core@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)':
+  '@dynamic-labs/sui-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/rpc-providers': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@mysten/sui': 1.24.0(typescript@5.9.3)
-      '@mysten/wallet-standard': 0.13.29(typescript@5.9.3)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@mysten/sui': 1.45.2(typescript@5.9.3)
+      '@mysten/wallet-standard': 0.19.9(typescript@5.9.3)
       text-encoding: 0.7.0
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
+      - bufferutil
+      - debug
       - react
       - react-dom
       - typescript
-
-  '@dynamic-labs/types@4.52.2':
-    dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
+      - utf-8-validate
 
   '@dynamic-labs/types@4.77.3':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.77.3
       '@dynamic-labs/sdk-api-core': 0.0.927
 
-  '@dynamic-labs/utils@4.52.2':
+  '@dynamic-labs/types@4.83.1':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/types': 4.52.2
-      buffer: 6.0.3
-      eventemitter3: 5.0.1
-      tldts: 6.0.16
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
 
   '@dynamic-labs/utils@4.77.3':
     dependencies:
@@ -4860,18 +4976,29 @@ snapshots:
       eventemitter3: 5.0.1
       tldts: 6.0.16
 
-  '@dynamic-labs/waas-evm@4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)':
+  '@dynamic-labs/utils@4.83.1':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/ethereum-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/waas': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      tldts: 6.0.16
+
+  '@dynamic-labs/waas-evm@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/ethereum-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/waas': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
       viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
       - bufferutil
@@ -4884,21 +5011,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@dynamic-labs/waas-svm@4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
+  '@dynamic-labs/waas-svm@4.83.1(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/rpc-providers': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/solana-core': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/waas': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@dynamic-labs/wallet-connector-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/embedded-wallet-solana': 4.83.1(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/solana-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/waas': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       bs58: 5.0.0
       eventemitter3: 5.0.1
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/forward-mpc-client'
+      - '@dynamic-labs-wallet/primitives'
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
       - bufferutil
@@ -4910,19 +5040,24 @@ snapshots:
       - typescript
       - utf-8-validate
       - viem
+      - zod
 
-  '@dynamic-labs/waas@4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
+  '@dynamic-labs/waas@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
     dependencies:
-      '@dynamic-labs-wallet/browser-wallet-client': 0.0.217(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/ethereum-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/solana-core': 4.52.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      '@dynamic-labs/sui-core': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs-sdk/client': 0.26.9(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs-wallet/browser-wallet-client': 0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/ethereum-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/solana-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@dynamic-labs/sui-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
       - bufferutil
@@ -4935,22 +5070,22 @@ snapshots:
       - utf-8-validate
       - viem
 
-  '@dynamic-labs/wallet-book@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
+  '@dynamic-labs/wallet-book@4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/iconic': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/iconic': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
       eventemitter3: 5.0.1
       react: 19.1.2
       react-dom: 19.1.2(react@19.1.2)
       util: 0.12.5
       zod: 4.0.5
 
-  '@dynamic-labs/wallet-connect@4.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)':
+  '@dynamic-labs/wallet-connect@4.83.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/logger': 4.52.2
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
       '@walletconnect/sign-client': 2.21.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -4977,24 +5112,31 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@dynamic-labs/wallet-connector-core@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
+  '@dynamic-labs/wallet-connector-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/logger': 4.52.2
-      '@dynamic-labs/rpc-providers': 4.52.2
-      '@dynamic-labs/sdk-api-core': 0.0.843
-      '@dynamic-labs/types': 4.52.2
-      '@dynamic-labs/utils': 4.52.2
-      '@dynamic-labs/wallet-book': 4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dynamic-labs-sdk/client': 0.26.9(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
+      '@dynamic-labs-wallet/browser-wallet-client': 0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
+      '@dynamic-labs/rpc-providers': 4.83.1
+      '@dynamic-labs/sdk-api-core': 0.0.964
+      '@dynamic-labs/types': 4.83.1
+      '@dynamic-labs/utils': 4.83.1
+      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
       eventemitter3: 5.0.1
     transitivePeerDependencies:
+      - '@dynamic-labs-wallet/primitives'
+      - bufferutil
+      - debug
       - react
       - react-dom
+      - utf-8-validate
 
-  '@dynamic-labs/webauthn@4.52.2':
+  '@dynamic-labs/webauthn@4.83.1':
     dependencies:
-      '@dynamic-labs/assert-package-version': 4.52.2
-      '@dynamic-labs/logger': 4.52.2
+      '@dynamic-labs/assert-package-version': 4.83.1
+      '@dynamic-labs/logger': 4.83.1
       '@simplewebauthn/browser': 13.1.0
       '@simplewebauthn/types': 12.0.0
 
@@ -5488,32 +5630,41 @@ snapshots:
 
   '@msgpack/msgpack@3.1.2': {}
 
-  '@mysten/bcs@1.5.0':
+  '@mysten/bcs@1.9.2':
     dependencies:
+      '@mysten/utils': 0.2.0
       '@scure/base': 1.2.6
 
-  '@mysten/sui@1.24.0(typescript@5.9.3)':
+  '@mysten/sui@1.45.2(typescript@5.9.3)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
-      '@mysten/bcs': 1.5.0
-      '@noble/curves': 1.9.7
+      '@mysten/bcs': 1.9.2
+      '@mysten/utils': 0.2.0
+      '@noble/curves': 1.9.4
       '@noble/hashes': 1.8.0
+      '@protobuf-ts/grpcweb-transport': 2.11.1
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
       '@scure/base': 1.2.6
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       gql.tada: 1.9.1(graphql@16.13.2)(typescript@5.9.3)
       graphql: 16.13.2
       poseidon-lite: 0.2.1
-      valibot: 0.36.0
+      valibot: 1.3.1(typescript@5.9.3)
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
       - typescript
 
-  '@mysten/wallet-standard@0.13.29(typescript@5.9.3)':
+  '@mysten/utils@0.2.0':
     dependencies:
-      '@mysten/sui': 1.24.0(typescript@5.9.3)
-      '@wallet-standard/core': 1.1.0
+      '@scure/base': 1.2.6
+
+  '@mysten/wallet-standard@0.19.9(typescript@5.9.3)':
+    dependencies:
+      '@mysten/sui': 1.45.2(typescript@5.9.3)
+      '@wallet-standard/core': 1.1.1
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
@@ -5590,6 +5741,10 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@noble/curves@1.9.4':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -5632,6 +5787,17 @@ snapshots:
   '@openzeppelin/contracts@4.9.6': {}
 
   '@paulmillr/qr@0.2.1': {}
+
+  '@protobuf-ts/grpcweb-transport@2.11.1':
+    dependencies:
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+
+  '@protobuf-ts/runtime-rpc@2.11.1':
+    dependencies:
+      '@protobuf-ts/runtime': 2.11.1
+
+  '@protobuf-ts/runtime@2.11.1': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6198,6 +6364,8 @@ snapshots:
 
   '@simplewebauthn/types@12.0.0': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@socket.io/component-emitter@3.1.2': {}
 
   '@solana/buffer-layout-utils@0.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
@@ -6303,7 +6471,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@solana/spl-token@0.4.12(@solana/web3.js@1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@solana/spl-token@0.4.14(@solana/web3.js@1.98.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -6348,6 +6516,10 @@ snapshots:
   '@swc/helpers@0.5.20':
     dependencies:
       tslib: 2.8.1
+
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
 
   '@tailwindcss/node@4.1.18':
     dependencies:
@@ -6549,6 +6721,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/cacheable-request@6.0.3':
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      '@types/keyv': 3.1.4
+      '@types/node': 20.19.27
+      '@types/responselike': 1.0.3
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 20.19.27
@@ -6559,9 +6738,15 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/http-cache-semantics@4.2.0': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/keyv@3.1.4':
+    dependencies:
+      '@types/node': 20.19.27
 
   '@types/lodash@4.17.24': {}
 
@@ -6580,6 +6765,10 @@ snapshots:
   '@types/react@19.1.12':
     dependencies:
       csstype: 3.2.3
+
+  '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 20.19.27
 
   '@types/trusted-types@2.0.7': {}
 
@@ -6761,7 +6950,7 @@ snapshots:
 
   '@wallet-standard/base@1.1.0': {}
 
-  '@wallet-standard/core@1.1.0':
+  '@wallet-standard/core@1.1.1':
     dependencies:
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
@@ -7345,6 +7534,21 @@ snapshots:
       typescript: 5.9.3
       zod: 4.3.5
 
+  ably@2.17.1(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6):
+    dependencies:
+      '@ably/msgpack-js': 0.4.1
+      dequal: 2.0.3
+      fastestsmallesttextencoderdecoder: 1.0.22
+      got: 11.8.6
+      ulid: 2.4.0
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      react: 19.1.2
+      react-dom: 19.1.2(react@19.1.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -7372,8 +7576,6 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
-
-  argon2id@1.0.1: {}
 
   argparse@2.0.1: {}
 
@@ -7473,19 +7675,19 @@ snapshots:
 
   axe-core@4.11.2: {}
 
-  axios@1.13.2:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
-  axios@1.9.0:
+  axios@1.15.2:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -7502,6 +7704,8 @@ snapshots:
   base-x@4.0.1: {}
 
   base-x@5.0.1: {}
+
+  base64-js@1.0.2: {}
 
   base64-js@1.5.1: {}
 
@@ -7522,6 +7726,11 @@ snapshots:
   blakejs@1.2.1: {}
 
   bn.js@5.2.3: {}
+
+  bops@1.0.1:
+    dependencies:
+      base64-js: 1.0.2
+      to-utf8: 0.0.1
 
   borsh@0.7.0:
     dependencies:
@@ -7578,6 +7787,18 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
 
+  cacheable-lookup@5.0.4: {}
+
+  cacheable-request@7.0.4:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -7623,6 +7844,10 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
 
   clsx@1.2.1: {}
 
@@ -7728,9 +7953,15 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-is@0.1.4: {}
 
   deepmerge@2.2.1: {}
+
+  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -7750,7 +7981,7 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  depd@2.0.0: {}
+  dequal@2.0.3: {}
 
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.1.12)(react@19.1.2)):
     dependencies:
@@ -8288,6 +8519,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -8314,6 +8549,20 @@ snapshots:
       gopd: 1.2.0
 
   gopd@1.2.0: {}
+
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
 
   gql.tada@1.9.1(graphql@16.13.2)(typescript@5.9.3):
     dependencies:
@@ -8381,13 +8630,12 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
-  http-errors@2.0.0:
+  http-cache-semantics@4.2.0: {}
+
+  http2-wrapper@1.0.3:
     dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      toidentifier: 1.0.1
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
 
   humanize-ms@1.2.1:
     dependencies:
@@ -8565,10 +8813,6 @@ snapshots:
     dependencies:
       ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
-  isows@1.0.6(ws@8.18.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
-    dependencies:
-      ws: 8.18.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-
   isows@1.0.7(ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       ws: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -8576,6 +8820,10 @@ snapshots:
   isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
+  isows@1.0.7(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -8731,6 +8979,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lowercase-keys@2.0.0: {}
+
   lru-cache@11.2.7: {}
 
   lucide-react@0.487.0(react@19.1.2):
@@ -8757,6 +9007,10 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -8823,6 +9077,8 @@ snapshots:
   node-releases@2.0.36: {}
 
   normalize-path@3.0.0: {}
+
+  normalize-url@6.1.0: {}
 
   obj-multiplex@1.0.0:
     dependencies:
@@ -8905,6 +9161,21 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  ox@0.12.4(typescript@5.9.3)(zod@4.3.5):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.5)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.14.7(typescript@5.9.3)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -8977,6 +9248,8 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
+
+  p-cancelable@2.1.1: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -9075,12 +9348,14 @@ snapshots:
 
   proxy-compare@2.6.0: {}
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode@1.3.2: {}
 
   punycode@2.3.1: {}
 
@@ -9105,9 +9380,13 @@ snapshots:
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
 
+  querystring@0.2.0: {}
+
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  quick-lru@5.1.1: {}
 
   radix3@1.1.2: {}
 
@@ -9223,6 +9502,8 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
+  resolve-alpn@1.2.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -9241,6 +9522,10 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
 
   reusify@1.1.0: {}
 
@@ -9315,8 +9600,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
-
-  setprototypeof@1.2.0: {}
 
   sha256-uint8array@0.10.7: {}
 
@@ -9445,8 +9728,6 @@ snapshots:
   split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
-
-  statuses@2.0.1: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -9579,7 +9860,7 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  toidentifier@1.0.1: {}
+  to-utf8@0.0.1: {}
 
   toposort@2.0.2: {}
 
@@ -9653,6 +9934,8 @@ snapshots:
     dependencies:
       multiformats: 9.9.0
 
+  ulid@2.4.0: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -9711,6 +9994,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url@0.11.0:
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+
   use-callback-ref@1.3.3(@types/react@19.1.12)(react@19.1.2):
     dependencies:
       react: 19.1.2
@@ -9755,7 +10043,9 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  valibot@0.36.0: {}
+  valibot@1.3.1(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   valtio@1.13.2(@types/react@19.1.12)(react@19.1.2):
     dependencies:
@@ -9783,23 +10073,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.29.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5):
-    dependencies:
-      '@noble/curves': 1.8.2
-      '@noble/hashes': 1.7.2
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.5)
-      isows: 1.0.6(ws@8.18.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      ox: 0.6.9(typescript@5.9.3)(zod@4.3.5)
-      ws: 8.18.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   viem@2.31.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5):
     dependencies:
       '@noble/curves': 1.9.1
@@ -9810,6 +10083,23 @@ snapshots:
       isows: 1.0.7(ws@8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.7.1(typescript@5.9.3)(zod@4.3.5)
       ws: 8.18.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.5)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      ox: 0.12.4(typescript@5.9.3)(zod@4.3.5)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9925,11 +10215,6 @@ snapshots:
       utf-8-validate: 6.0.6
 
   ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-
-  ws@8.18.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6

--- a/examples/nextjs-iron-ramp/pnpm-lock.yaml
+++ b/examples/nextjs-iron-ramp/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@dynamic-labs/ethereum':
         specifier: 4.52.2
         version: 4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)
-      '@dynamic-labs/ethereum-aa':
-        specifier: ^4.83.1
-        version: 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(@zerodev/webauthn-key@5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
       '@dynamic-labs/sdk-react-core':
         specifier: 4.52.2
         version: 4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
@@ -107,9 +104,6 @@ packages:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.0.0
 
-  '@ably/msgpack-js@0.4.1':
-    resolution: {integrity: sha512-Sjxj6SOr17hExAVrsycN7u6oV4PhZcK7Z2S8dM71CH/butgO47cSo/TL6FJPCXUyDAzKkOWjMUpJGyZkEpyu4Q==}
-
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
@@ -137,26 +131,14 @@ packages:
   '@dynamic-labs-sdk/assert-package-version@0.1.2':
     resolution: {integrity: sha512-riWzoNe0NoS0nSWX3pqQ0Tjt3OAIufI0LpuVR0SQwGA1Xr8BsZZs+RKb+cxDMtpyKE+ZaA+U3GEN+UXr2FYm/A==}
 
-  '@dynamic-labs-sdk/assert-package-version@0.26.9':
-    resolution: {integrity: sha512-hB9VvQOhE9j2EHAQfv7LCoLH8+DQXzYveHbsEK5dlU3BB4FoZTdJEU2SEH34q+g7Hyz3Nb+ioc5//jrr/tb39w==}
-
   '@dynamic-labs-sdk/client@0.1.2':
     resolution: {integrity: sha512-2GYWnVGwtD1xfpQunUvmISDlrsAnY7e9rjvebvuAtMy9st9PhZxomLxd0kj9v2sX4R+mxtD0vKuXMS0+p+tJ/Q==}
-
-  '@dynamic-labs-sdk/client@0.26.9':
-    resolution: {integrity: sha512-ubdqCkyiER9Ruc63E4IomvsOMMzSjGbFNeGnn3hIipzamPslrlAO9YTcU50qJEFioMneA2iJ00kbSBx+1VWHmw==}
 
   '@dynamic-labs-wallet/browser-wallet-client@0.0.211':
     resolution: {integrity: sha512-ZYtpKlisiDejEiD2oFIpcpkjFM0UMLTuRZ0gzEe+ybBn4e3g+Yt0XjKdcAPHvQVeIb94TgtZqLmxRW/lQz9hSQ==}
 
   '@dynamic-labs-wallet/browser-wallet-client@0.0.217':
     resolution: {integrity: sha512-t9N1Ml94emoi4o2SxdMzBodlNCOaTsuedIGR2p3ABoF5GddErp3DocNoE5rgOC+U8GdAz9s0N/u9WMRkwHn2Xw==}
-
-  '@dynamic-labs-wallet/browser-wallet-client@0.0.325':
-    resolution: {integrity: sha512-niU6U2OPNg0aPMpQ+yqoTFYayKoRpLSxQg56mKHWM9RmbilGH5jHWXH3mEAVGS7u5YEAuZDnnCavBdWYSBsK5Q==}
-
-  '@dynamic-labs-wallet/browser-wallet-client@0.0.337':
-    resolution: {integrity: sha512-0fZyXUfiZf/mPvvWl+kI4NqUAddWT18dWPRoM08xDUMZ8wGJmyWgD0MeqyJjHV92CV2by2cV+TRcEK3gnaf1sQ==}
 
   '@dynamic-labs-wallet/browser@0.0.167':
     resolution: {integrity: sha512-HDmUetnJ1iz6kGd5PB1kJzeLI7ZJmwxlJ1QGtUqSQHDdBkhLwaDPlccB2IviC5iPfU5PR/IQ1BYEqpoTWx2sBA==}
@@ -170,43 +152,17 @@ packages:
   '@dynamic-labs-wallet/core@0.0.217':
     resolution: {integrity: sha512-TzIyCYlcwFTOTHpr4phU7xQmkY+f76OTiPM/LZ9gW9m0Ji1ETokHfhv6nuLOQSbctGviTdrGxWF1Y1uhaLJEDQ==}
 
-  '@dynamic-labs-wallet/core@0.0.325':
-    resolution: {integrity: sha512-kWlCPMjHVBwiKyWUYrQrsgfTL2Mszsk1acjxJqfsWJucfgOxp432uO5XHGivosu3T1hfGNBNyKK6bChy3gL9Nw==}
-    peerDependencies:
-      '@dynamic-labs-wallet/forward-mpc-client': 0.5.5
-
-  '@dynamic-labs-wallet/core@0.0.337':
-    resolution: {integrity: sha512-csS/Xqx9kERTYLzt7BXHkaIBX8WIfUIDC3R0Yv6fweWdRL+6KX0A6lRUN1lajAF9/7d6XhxVzS/C3umS0qd7JQ==}
-    peerDependencies:
-      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0
-
   '@dynamic-labs-wallet/forward-mpc-client@0.1.3':
     resolution: {integrity: sha512-riZesfU41fMvetaxJ3bO48/9P8ikRPgoVJgWh8m8i0oRyYN7uUz+Iesp+52U12DCtcvSTXljxrKtrV3yqNAYRw==}
 
-  '@dynamic-labs-wallet/forward-mpc-client@0.9.0':
-    resolution: {integrity: sha512-gotV/RnPTJmjosddbZU6L9Rgs6WEJRwNX/VO7v+0JKyyuzIZPvjA2wJLto9EVEiNMCKMES2a+VY39rEqcGNHCg==}
-    peerDependencies:
-      '@dynamic-labs-wallet/primitives': '>=0.0.336 || 0.0.1'
-
   '@dynamic-labs-wallet/forward-mpc-shared@0.1.0':
     resolution: {integrity: sha512-xRpMri4+ZuClonwf04RcnT/BCG8oA36ononD7s0MA5wSqd8kOuHjzNTSoM6lWnPiCmlpECyPARJ1CEO02Sfq9Q==}
-
-  '@dynamic-labs-wallet/forward-mpc-shared@0.7.0':
-    resolution: {integrity: sha512-mN6zT5J8JbZxkOJxEjgGrjURybVn/t9DD+pWW5U4DRZH6Qakn5n1LIB4Lg4Y7OW9WwrlMH2IJ9RNgBW35RaF1A==}
-    peerDependencies:
-      '@dynamic-labs-wallet/primitives': '>=0.0.336 || 0.0.1'
-
-  '@dynamic-labs-wallet/primitives@0.0.337':
-    resolution: {integrity: sha512-bhF0KBTQ+Ej/gZN/70fDd/ldy3Srqg/NgxzmKhUxMT31uY7OvCNblZ8r5gS6mjiNt+PhF8WmjOdEI5lCD6AjXQ==}
 
   '@dynamic-labs/assert-package-version@4.52.2':
     resolution: {integrity: sha512-zpc0F5zUOBx0LcJ4iHZz9hSq4cl4rpCeNWzqQ/VrI3nEET+beU7AP/dYDFTIrD3DAE5KfpapK9IDt8ymkwVBmg==}
 
   '@dynamic-labs/assert-package-version@4.77.3':
     resolution: {integrity: sha512-MBMSg/eFrAgAnEhk0U1KdqN8zFny1vyO5HCsHRccyvkH5FuRFisnvT1Q0TKGWfPtB4SJePN9VSJDePW1MJGZIg==}
-
-  '@dynamic-labs/assert-package-version@4.83.1':
-    resolution: {integrity: sha512-wSpNfNxoaUVGGYQWGnvyiEuwoNr5YA9dTQZizvnEyCvI/HfipVsQRJjp63ysbPFmqLUFHvwYEDjcHE/+5/V62w==}
 
   '@dynamic-labs/embedded-wallet-evm@4.52.2':
     resolution: {integrity: sha512-nxinY85HRZCKwtlC3yL2e9PJp74tD6ZXB4THF9DL32QOySCiFuXvsftekcFzyrPN1J7nyAJBe++tnW785sxzcA==}
@@ -219,25 +175,10 @@ packages:
   '@dynamic-labs/embedded-wallet@4.52.2':
     resolution: {integrity: sha512-oAp1ugcux6Ao2CyehhVXTYkiH9jrxBaCPmrSkp0kwJfitrGd92j6AkFgymI5gtNG/vLXjd2z/KcF+r9uNTedZQ==}
 
-  '@dynamic-labs/ethereum-aa-core@4.83.1':
-    resolution: {integrity: sha512-XhxzO3LZUmek5IMNZjGzlEd5Rm6dCaSuAgBbn+Z+k74Yvaf4WtmE41rzkQZXTnMKTt9WX5XwmzTgTh1gJPlXIA==}
-    peerDependencies:
-      viem: ^2.45.3
-
-  '@dynamic-labs/ethereum-aa@4.83.1':
-    resolution: {integrity: sha512-mnxm99ZY6yVGTvS1CxeOStoH/Y6TB77wHAZGQbtm8u3jIYUjRCtq+k8Q1LWd50jbw3Cog/igMleQB7qhBqQ3SQ==}
-    peerDependencies:
-      viem: ^2.45.3
-
   '@dynamic-labs/ethereum-core@4.52.2':
     resolution: {integrity: sha512-Ly3ILM5YXjs84g5UZfxkgbmodcr34IGI9mYiJQr7XGgMt/HhDOXySeDxo+rwkeWZxFctCFtbOZ1U46O4+XstBQ==}
     peerDependencies:
       viem: ^2.28.4
-
-  '@dynamic-labs/ethereum-core@4.83.1':
-    resolution: {integrity: sha512-xPuxfgzBtj+KGjjOKN/2N3W171rOj9JFKfa92oDLTLv4jt9rfOPottUYgMGf4MGhqWnu8cbnbBlRr5DWukUqhA==}
-    peerDependencies:
-      viem: ^2.45.3
 
   '@dynamic-labs/ethereum@4.52.2':
     resolution: {integrity: sha512-cxrJciTzy7WOi8qGA+l3yD4dRYlwFuRt5UBxzHjty8g9q3rxlwwDja3aaC8XIfeUmEYv47soZ1st17dxwrO8yQ==}
@@ -246,12 +187,6 @@ packages:
 
   '@dynamic-labs/iconic@4.52.2':
     resolution: {integrity: sha512-QHgiTGFcArcboYlOUknlB3X4sKY3S2MrBD+F3UGu5MxrPDUsE2Icloh0DQ1vWia7oND71hbTcf1NOpAKR1EBiQ==}
-    peerDependencies:
-      react: '>=18.0.0 <20.0.0'
-      react-dom: '>=18.0.0 <20.0.0'
-
-  '@dynamic-labs/iconic@4.83.1':
-    resolution: {integrity: sha512-tYU1XYsI426LRnRp1ID1MybyXTitBXNTOZ+SKOWrNzqSnC503li6d4dm7pjuWAT0OZlpMlGw2bL0ZpV66Uojqw==}
     peerDependencies:
       react: '>=18.0.0 <20.0.0'
       react-dom: '>=18.0.0 <20.0.0'
@@ -277,9 +212,6 @@ packages:
   '@dynamic-labs/rpc-providers@4.52.2':
     resolution: {integrity: sha512-fdv0W+kzd4tnici0lDFWcNtg2mZHZBSrQdUsbrrBSpdENnzk3pqNkJP/keLMAwIYH397C3qbK4my0BoQzROPwQ==}
 
-  '@dynamic-labs/rpc-providers@4.83.1':
-    resolution: {integrity: sha512-KghsNAHBwoRoKN/FPuUfT1yQ+Kf7KhxuHcsH+XINfA90/zMLQrOKIsKeUyBboWWwCJrqCcGsG+lqUmxbCrBasw==}
-
   '@dynamic-labs/sdk-api-core@0.0.764':
     resolution: {integrity: sha512-79JptJTTClLc9qhioThtwMuzTHJ+mrj8sTEglb7Mcx3lJub9YbXqNdzS9mLRxZsr2et3aqqpzymXdUBzSEaMng==}
 
@@ -289,17 +221,8 @@ packages:
   '@dynamic-labs/sdk-api-core@0.0.843':
     resolution: {integrity: sha512-+4tcNWsKuPzt+suJax3jprwyI+w2gbEbSkzeuvI9/x1B9AuFPvIMxILoVqK9hEsrT57APQHnmTOkxSNk7aDgPA==}
 
-  '@dynamic-labs/sdk-api-core@0.0.900':
-    resolution: {integrity: sha512-4kb6IY75fFbTLwW24hN8ziVuxEeGAtsQpvXlKXA/XYrPKFFtJU6VQnuiKrKAerekIltdfMXEIqBJpcdPsmbszg==}
-
   '@dynamic-labs/sdk-api-core@0.0.927':
     resolution: {integrity: sha512-jL0XRN9GzKeN2wcppD8Ixt2Q7VtkNSbBv6up6el8vutsiQ8ZxA/eX/Wb1ysw8TXiIcDUl2p0afyWwkSxIj+8rw==}
-
-  '@dynamic-labs/sdk-api-core@0.0.958':
-    resolution: {integrity: sha512-jbDSjxWi69Nb5ZRmMrt+tV1gqGoPflvZnw7Qlpmbxbfguqx8KBzvDdDphMJ5jW2YCEmD8dRw2qizOrnN1gjIxw==}
-
-  '@dynamic-labs/sdk-api-core@0.0.964':
-    resolution: {integrity: sha512-U7PdyUQXdvToWCoysBIURYDMy+3XTnGZsdruv1Bl1LKwXHNbR8jGwIt6ibf0vbp1lQga6fc4DPnlAjbtUHaPIA==}
 
   '@dynamic-labs/sdk-react-core@4.52.2':
     resolution: {integrity: sha512-Xk2f6UcIOY3QbXRlwhizHF6Gd+PRMjuIuW4DbKIMfrz8WGKyKF/Qh7AQTJ3ReKYm1KevCbCNLsn0c14/p3F9sA==}
@@ -325,17 +248,11 @@ packages:
   '@dynamic-labs/types@4.77.3':
     resolution: {integrity: sha512-tP45k6blfuuWDt8Vua+ZcvxM3DxkiieIg7vSt5aXUgBbaFFygnz98d1u+n1PD9np2NqDWyCUjMJE71Uk2HLrFg==}
 
-  '@dynamic-labs/types@4.83.1':
-    resolution: {integrity: sha512-lwNz57iJLk/bySkGVxeYIbWZvmb18s9yD2QbXQguyChu6V4/PdoRH4DGBr9xxOMY06zzSVSN3g2ctrsepv4atg==}
-
   '@dynamic-labs/utils@4.52.2':
     resolution: {integrity: sha512-3rvKPjjc7zvC8E30E5UYSfx0ZBjNNKqziJDw/N0p5KvbIWech4y5xHkaNmW6vxWTRT89trwtbtyrPJuRoK3rsg==}
 
   '@dynamic-labs/utils@4.77.3':
     resolution: {integrity: sha512-UeSy8YYvbKwMbCmVkcxrVb9f7k0Oe5MYn2R6k1+phsgG4Zfst8IyN/d4KgKDSBZaeKnYN5z+ZekgBLJzeRtA5g==}
-
-  '@dynamic-labs/utils@4.83.1':
-    resolution: {integrity: sha512-6PgT0Xr8IQUn4xx3fBn2XEcyA9NAnR/BSVEsOb/+KgFRhx7bmKkwC3Bh1ooCXpr9P/osutT9Yy+Eb/3rg182CA==}
 
   '@dynamic-labs/waas-evm@4.52.2':
     resolution: {integrity: sha512-rWn+1aFWK0a/95wEiyg1qyusTJvxC6VKiIdITNsXeLZkBXkMy8HFPHeD5lBjW8mVOn5HRcAGHLYAYfpINSncfw==}
@@ -352,20 +269,11 @@ packages:
       react: '>=18.0.0 <20.0.0'
       react-dom: '>=18.0.0 <20.0.0'
 
-  '@dynamic-labs/wallet-book@4.83.1':
-    resolution: {integrity: sha512-FNCQsS8U1l2SgvbZAESJcBcVcVJ7EeQrazNiEIKze4gcAwlJXDMoa/ThbN/dUOGaY1smM0A8TOKiBER96+t7OA==}
-    peerDependencies:
-      react: '>=18.0.0 <20.0.0'
-      react-dom: '>=18.0.0 <20.0.0'
-
   '@dynamic-labs/wallet-connect@4.52.2':
     resolution: {integrity: sha512-h4nSQdkfRnT82wHPsv1gFk3V7wLmL0dMRtglkhri3cghIHwSfCaW0AYLArhojEQ68gitnvS42oWfeC+QE0waWg==}
 
   '@dynamic-labs/wallet-connector-core@4.52.2':
     resolution: {integrity: sha512-bAINAsC4Ydz7/UjctOrRSNZG8xhg7YZQkMLnz0uX5t/hB71UiFpnU890bJQJg95YjYHsHmHw1PUBCCI6sONnHw==}
-
-  '@dynamic-labs/wallet-connector-core@4.83.1':
-    resolution: {integrity: sha512-lYAuLgMB8aKqT+M+vftUslIy5YlArs4LxcwCHZgQNoly1UB9CEjGSJFQBQmZQIrmz7TB+8H8V11uHhGu/Ow3IQ==}
 
   '@dynamic-labs/webauthn@4.52.2':
     resolution: {integrity: sha512-RytiwqsCWB8TiYFr8Xb3cj7JmumUMyz2wz49phK/wA5WS2F/t6OUt4cW/QMBEfVhgvq1YOIn7fKuFFlsTeDv4A==}
@@ -1398,27 +1306,9 @@ packages:
   '@simplewebauthn/browser@13.1.0':
     resolution: {integrity: sha512-WuHZ/PYvyPJ9nxSzgHtOEjogBhwJfC8xzYkPC+rR/+8chl/ft4ngjiK8kSU5HtRJfczupyOh33b25TjYbvwAcg==}
 
-  '@simplewebauthn/browser@8.3.7':
-    resolution: {integrity: sha512-ZtRf+pUEgOCvjrYsbMsJfiHOdKcrSZt2zrAnIIpfmA06r0FxBovFYq0rJ171soZbe13KmWzAoLKjSxVW7KxCdQ==}
-
-  '@simplewebauthn/browser@9.0.1':
-    resolution: {integrity: sha512-wD2WpbkaEP4170s13/HUxPcAV5y4ZXaKo1TfNklS5zDefPinIgXOpgz1kpEvobAsaLPa2KeH7AKKX/od1mrBJw==}
-
   '@simplewebauthn/types@12.0.0':
     resolution: {integrity: sha512-q6y8MkoV8V8jB4zzp18Uyj2I7oFp2/ONL8c3j8uT06AOWu3cIChc1au71QYHrP2b+xDapkGTiv+9lX7xkTlAsA==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  '@simplewebauthn/types@9.0.1':
-    resolution: {integrity: sha512-tGSRP1QvsAvsJmnOlRQyw/mvK9gnPtjEc5fg2+m8n+QUa+D7rvrKkOYyfpy42GTs90X3RDOnqJgfHt+qO67/+w==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  '@simplewebauthn/typescript-types@8.3.4':
-    resolution: {integrity: sha512-38xtca0OqfRVNloKBrFB5LEM6PN5vzFbJG6rAutPVrtGHFYxPdiV3btYWq0eAZAZmP+dqFPYJxJWeJrGfmYHng==}
-    deprecated: This package has been renamed to @simplewebauthn/types. Please install @simplewebauthn/types instead to ensure you receive future updates.
-
-  '@sindresorhus/is@4.6.0':
-    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
-    engines: {node: '>=10'}
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
@@ -1513,10 +1403,6 @@ packages:
 
   '@swc/helpers@0.5.20':
     resolution: {integrity: sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==}
-
-  '@szmarczak/http-timer@4.0.6':
-    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
-    engines: {node: '>=10'}
 
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
@@ -1678,9 +1564,6 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  '@types/cacheable-request@6.0.3':
-    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
-
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -1690,17 +1573,11 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/http-cache-semantics@4.2.0':
-    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  '@types/keyv@3.1.4':
-    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
@@ -1721,9 +1598,6 @@ packages:
 
   '@types/react@19.1.12':
     resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
-
-  '@types/responselike@1.0.3':
-    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2039,29 +1913,6 @@ packages:
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
 
-  '@zerodev/ecdsa-validator@5.4.9':
-    resolution: {integrity: sha512-9NVE8/sQIKRo42UOoYKkNdmmHJY8VlT4t+2MHD2ipLg21cpbY9fS17TGZh61+Bl3qlqc8pP23I6f89z9im7kuA==}
-    peerDependencies:
-      '@zerodev/sdk': ^5.4.13
-      viem: ^2.28.0
-
-  '@zerodev/multi-chain-ecdsa-validator@5.4.5':
-    resolution: {integrity: sha512-cmQcsl5WbjnyQuhAS76BUqsHGtUOfWqdkMlm60s75kmRKzF5PiKzRpWIZyeISVmJV0F4P5u1keo1xYONEFiw1w==}
-    peerDependencies:
-      '@zerodev/sdk': ^5.4.0
-      '@zerodev/webauthn-key': ^5.4.0
-      viem: ^2.28.0
-
-  '@zerodev/sdk@5.5.7':
-    resolution: {integrity: sha512-Sf4G13yi131H8ujun64obvXIpk1UWn64GiGJjfvGx8aIKg+OWTRz9AZHgGKK+bE/evAmqIg4nchuSvKPhOau1w==}
-    peerDependencies:
-      viem: ^2.28.0
-
-  '@zerodev/webauthn-key@5.5.0':
-    resolution: {integrity: sha512-AbD2d/qrsX7AWxJMEfwxnLbp1TjiUjc1V4ne3Q40UJxKe+lW64Td+y8OD0qSFMqgN6rQxJZ0aOAXmat8H6xluA==}
-    peerDependencies:
-      viem: ^2.28.0
-
   abitype@1.0.8:
     resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
     peerDependencies:
@@ -2082,18 +1933,6 @@ packages:
       typescript:
         optional: true
       zod:
-        optional: true
-
-  ably@2.17.1:
-    resolution: {integrity: sha512-70yfXHoM7JtJD/8FCtPD1gkWW0f+AJqbJp0PsqDAqiyxFB8cPFY+FuKHgNTYb8eRHKXq8hT1xiDphUcY0+GHnA==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
         optional: true
 
   acorn-jsx@5.3.2:
@@ -2203,12 +2042,6 @@ packages:
   axios@1.13.2:
     resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
-
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
-
   axios@1.9.0:
     resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
 
@@ -2231,10 +2064,6 @@ packages:
 
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
-
-  base64-js@1.0.2:
-    resolution: {integrity: sha512-ZXBDPMt/v/8fsIqn+Z5VwrhdR6jVka0bYobHdGia0Nxi7BJ9i/Uvml3AocHIBtIIBhZjBw5MR0aR4ROs/8+SNg==}
-    engines: {node: '>= 0.4'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2260,14 +2089,8 @@ packages:
   blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
 
-  bn.js@4.11.6:
-    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
-
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
-
-  bops@1.0.1:
-    resolution: {integrity: sha512-qCMBuZKP36tELrrgXpAfM+gHzqa0nLsWZ+L37ncsb8txYlnAoxOPpVp+g7fK0sGkMXfA0wl8uQkESqw3v4HNag==}
 
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
@@ -2303,23 +2126,12 @@ packages:
   bs58check@4.0.0:
     resolution: {integrity: sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==}
 
-  buffer-reverse@1.0.1:
-    resolution: {integrity: sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==}
-
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bufferutil@4.1.0:
     resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
     engines: {node: '>=6.14.2'}
-
-  cacheable-lookup@5.0.4:
-    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
-    engines: {node: '>=10.6.0'}
-
-  cacheable-request@7.0.4:
-    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
-    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2364,9 +2176,6 @@ packages:
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
-
-  clone-response@1.0.3:
-    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
   clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
@@ -2439,9 +2248,6 @@ packages:
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
-  crypto-js@4.2.0:
-    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
-
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2492,20 +2298,12 @@ packages:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   deepmerge@2.2.1:
     resolution: {integrity: sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==}
     engines: {node: '>=0.10.0'}
-
-  defer-to-connect@2.0.1:
-    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
-    engines: {node: '>=10'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -2529,10 +2327,6 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
-
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
 
   derive-valtio@0.1.0:
     resolution: {integrity: sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==}
@@ -2771,15 +2565,8 @@ packages:
   eth-rpc-errors@4.0.3:
     resolution: {integrity: sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==}
 
-  ethereum-bloom-filters@1.2.0:
-    resolution: {integrity: sha512-28hyiE7HVsWubqhpVLVmZXFd4ITeHi+BUu05o9isf0GUpMtzBUi+8/gFrGaGYzvGAJQmJ3JKj77Mk9G98T84rA==}
-
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
-
-  ethjs-unit@0.1.6:
-    resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
-    engines: {node: '>=6.5.0', npm: '>=3'}
 
   eventemitter2@6.4.9:
     resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
@@ -2929,10 +2716,6 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -2959,10 +2742,6 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-
-  got@11.8.6:
-    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
-    engines: {node: '>=10.19.0'}
 
   gql.tada@1.9.1:
     resolution: {integrity: sha512-Ijtwgw08aE7l06wK5oj5Msgpk9SUe5FSVcuxU5dHyefdM7fDqLQpA76yHBoq8lPB3MNSir8tznodDknHkm2Z/w==}
@@ -3017,16 +2796,9 @@ packages:
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
 
-  http-cache-semantics@4.2.0:
-    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
-
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
-
-  http2-wrapper@1.0.3:
-    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
-    engines: {node: '>=10.19.0'}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -3135,10 +2907,6 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
-
-  is-hex-prefixed@1.0.0:
-    resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==}
-    engines: {node: '>=6.5.0', npm: '>=3'}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -3383,10 +3151,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  lowercase-keys@2.0.0:
-    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
-    engines: {node: '>=8'}
-
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
@@ -3407,10 +3171,6 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  merkletreejs@0.3.11:
-    resolution: {integrity: sha512-LJKTl4iVNTndhL+3Uz/tfkjD0klIWsHlUzgtuNnNrsf7bAlXR30m+xYB7lHr5Z/l6e/yAIsr26Dabx6Buo4VGQ==}
-    engines: {node: '>= 7.6.0'}
-
   micro-ftch@0.3.1:
     resolution: {integrity: sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==}
 
@@ -3425,14 +3185,6 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
-
-  mimic-response@1.0.1:
-    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
-    engines: {node: '>=4'}
-
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -3516,14 +3268,6 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-
-  normalize-url@6.1.0:
-    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
-    engines: {node: '>=10'}
-
-  number-to-bn@1.7.0:
-    resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
-    engines: {node: '>=6.5.0', npm: '>=3'}
 
   obj-multiplex@1.0.0:
     resolution: {integrity: sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA==}
@@ -3614,10 +3358,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  p-cancelable@2.1.1:
-    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
-    engines: {node: '>=8'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -3729,15 +3469,8 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
-
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
-  punycode@1.3.2:
-    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3757,26 +3490,14 @@ packages:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
 
-  querystring@0.2.0:
-    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
-    engines: {node: '>=0.4.x'}
-    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
-
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
-  quick-lru@5.1.1:
-    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
-    engines: {node: '>=10'}
-
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
-
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
   react-clientside-effect@1.2.8:
     resolution: {integrity: sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==}
@@ -3885,9 +3606,6 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
-  resolve-alpn@1.2.1:
-    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
-
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3904,9 +3622,6 @@ packages:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
     hasBin: true
-
-  responselike@2.0.1:
-    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -4096,10 +3811,6 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
-  strip-hex-prefix@1.0.0:
-    resolution: {integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==}
-    engines: {node: '>=6.5.0', npm: '>=3'}
-
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -4167,9 +3878,6 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  to-utf8@0.0.1:
-    resolution: {integrity: sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ==}
-
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -4179,10 +3887,6 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
-  treeify@1.1.0:
-    resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
-    engines: {node: '>=0.6'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -4238,10 +3942,6 @@ packages:
 
   uint8arrays@3.1.1:
     resolution: {integrity: sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==}
-
-  ulid@2.4.0:
-    resolution: {integrity: sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==}
-    hasBin: true
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -4327,9 +4027,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  url@0.11.0:
-    resolution: {integrity: sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==}
-
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -4362,9 +4059,6 @@ packages:
   utf-8-validate@6.0.6:
     resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
     engines: {node: '>=6.14.2'}
-
-  utf8@3.0.0:
-    resolution: {integrity: sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -4434,10 +4128,6 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
-
-  web3-utils@1.10.4:
-    resolution: {integrity: sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==}
-    engines: {node: '>=8.0.0'}
 
   webextension-polyfill@0.10.0:
     resolution: {integrity: sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==}
@@ -4617,10 +4307,6 @@ snapshots:
       graphql: 16.13.2
       typescript: 5.9.3
 
-  '@ably/msgpack-js@0.4.1':
-    dependencies:
-      bops: 1.0.1
-
   '@adraffy/ens-normalize@1.11.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
@@ -4678,8 +4364,6 @@ snapshots:
 
   '@dynamic-labs-sdk/assert-package-version@0.1.2': {}
 
-  '@dynamic-labs-sdk/assert-package-version@0.26.9': {}
-
   '@dynamic-labs-sdk/client@0.1.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@dynamic-labs-sdk/assert-package-version': 0.1.2
@@ -4692,24 +4376,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - debug
-      - utf-8-validate
-
-  '@dynamic-labs-sdk/client@0.26.9(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@dynamic-labs-sdk/assert-package-version': 0.26.9
-      '@dynamic-labs-wallet/browser-wallet-client': 0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@dynamic-labs/sdk-api-core': 0.0.958
-      '@simplewebauthn/browser': 13.1.0
-      ably: 2.17.1(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
-      buffer: 6.0.3
-      eventemitter3: 5.0.1
-      zod: 4.0.5
-    transitivePeerDependencies:
-      - '@dynamic-labs-wallet/forward-mpc-client'
-      - bufferutil
-      - debug
-      - react
-      - react-dom
       - utf-8-validate
 
   '@dynamic-labs-wallet/browser-wallet-client@0.0.211(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
@@ -4733,24 +4399,6 @@ snapshots:
       - bufferutil
       - debug
       - utf-8-validate
-
-  '@dynamic-labs-wallet/browser-wallet-client@0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
-    dependencies:
-      '@dynamic-labs-wallet/core': 0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@dynamic-labs/logger': 4.83.1
-      '@dynamic-labs/message-transport': 4.77.3
-    transitivePeerDependencies:
-      - '@dynamic-labs-wallet/forward-mpc-client'
-      - debug
-
-  '@dynamic-labs-wallet/browser-wallet-client@0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
-    dependencies:
-      '@dynamic-labs-wallet/core': 0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@dynamic-labs/logger': 4.83.1
-      '@dynamic-labs/message-transport': 4.77.3
-    transitivePeerDependencies:
-      - '@dynamic-labs-wallet/forward-mpc-client'
-      - debug
 
   '@dynamic-labs-wallet/browser@0.0.167':
     dependencies:
@@ -4800,25 +4448,6 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@dynamic-labs-wallet/core@0.0.325(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
-    dependencies:
-      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/sdk-api-core': 0.0.900
-      axios: 1.15.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - debug
-
-  '@dynamic-labs-wallet/core@0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
-    dependencies:
-      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs-wallet/primitives': 0.0.337
-      '@dynamic-labs/sdk-api-core': 0.0.964
-      axios: 1.15.2
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - debug
-
   '@dynamic-labs-wallet/forward-mpc-client@0.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@dynamic-labs-wallet/core': 0.0.167
@@ -4834,20 +4463,6 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@dynamic-labs-wallet/forward-mpc-shared': 0.7.0(@dynamic-labs-wallet/primitives@0.0.337)
-      '@dynamic-labs-wallet/primitives': 0.0.337
-      '@evervault/wasm-attestation-bindings': 0.3.1
-      '@noble/hashes': 2.0.1
-      eventemitter3: 5.0.1
-      fp-ts: 2.16.11
-      isows: 1.0.7(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   '@dynamic-labs-wallet/forward-mpc-shared@0.1.0':
     dependencies:
       '@dynamic-labs-wallet/browser': 0.0.167
@@ -4860,17 +4475,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@dynamic-labs-wallet/forward-mpc-shared@0.7.0(@dynamic-labs-wallet/primitives@0.0.337)':
-    dependencies:
-      '@dynamic-labs-wallet/primitives': 0.0.337
-      '@noble/ciphers': 0.4.1
-      '@noble/hashes': 2.0.1
-      '@noble/post-quantum': 0.5.4
-      fp-ts: 2.16.11
-      io-ts: 2.2.22(fp-ts@2.16.11)
-
-  '@dynamic-labs-wallet/primitives@0.0.337': {}
-
   '@dynamic-labs/assert-package-version@4.52.2':
     dependencies:
       '@dynamic-labs/logger': 4.52.2
@@ -4878,10 +4482,6 @@ snapshots:
   '@dynamic-labs/assert-package-version@4.77.3':
     dependencies:
       '@dynamic-labs/logger': 4.77.3
-
-  '@dynamic-labs/assert-package-version@4.83.1':
-    dependencies:
-      '@dynamic-labs/logger': 4.83.1
 
   '@dynamic-labs/embedded-wallet-evm@4.52.2(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
     dependencies:
@@ -4955,48 +4555,6 @@ snapshots:
       - react
       - react-dom
 
-  '@dynamic-labs/ethereum-aa-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
-    dependencies:
-      '@dynamic-labs/assert-package-version': 4.83.1
-      '@dynamic-labs/ethereum-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@dynamic-labs/sdk-api-core': 0.0.964
-      '@dynamic-labs/types': 4.83.1
-      '@dynamic-labs/utils': 4.83.1
-      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
-      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
-    transitivePeerDependencies:
-      - '@dynamic-labs-wallet/primitives'
-      - bufferutil
-      - debug
-      - react
-      - react-dom
-      - utf-8-validate
-
-  '@dynamic-labs/ethereum-aa@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(@zerodev/webauthn-key@5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
-    dependencies:
-      '@dynamic-labs/assert-package-version': 4.83.1
-      '@dynamic-labs/ethereum-aa-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@dynamic-labs/ethereum-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@dynamic-labs/logger': 4.83.1
-      '@dynamic-labs/sdk-api-core': 0.0.964
-      '@dynamic-labs/types': 4.83.1
-      '@dynamic-labs/utils': 4.83.1
-      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
-      '@zerodev/ecdsa-validator': 5.4.9(@zerodev/sdk@5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@zerodev/multi-chain-ecdsa-validator': 5.4.5(@zerodev/sdk@5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(@zerodev/webauthn-key@5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@zerodev/sdk': 5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
-    transitivePeerDependencies:
-      - '@dynamic-labs-wallet/primitives'
-      - '@zerodev/webauthn-key'
-      - bufferutil
-      - debug
-      - react
-      - react-dom
-      - utf-8-validate
-
   '@dynamic-labs/ethereum-core@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.52.2
@@ -5011,25 +4569,6 @@ snapshots:
     transitivePeerDependencies:
       - react
       - react-dom
-
-  '@dynamic-labs/ethereum-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
-    dependencies:
-      '@dynamic-labs/assert-package-version': 4.83.1
-      '@dynamic-labs/logger': 4.83.1
-      '@dynamic-labs/rpc-providers': 4.83.1
-      '@dynamic-labs/sdk-api-core': 0.0.964
-      '@dynamic-labs/types': 4.83.1
-      '@dynamic-labs/utils': 4.83.1
-      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/wallet-connector-core': 4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
-      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
-    transitivePeerDependencies:
-      - '@dynamic-labs-wallet/primitives'
-      - bufferutil
-      - debug
-      - react
-      - react-dom
-      - utf-8-validate
 
   '@dynamic-labs/ethereum@4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.1.2))(utf-8-validate@6.0.6)(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))(zod@4.3.5)':
     dependencies:
@@ -5094,15 +4633,6 @@ snapshots:
       react-dom: 19.1.2(react@19.1.2)
       sharp: 0.33.5
 
-  '@dynamic-labs/iconic@4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
-    dependencies:
-      '@dynamic-labs/assert-package-version': 4.83.1
-      '@dynamic-labs/logger': 4.83.1
-      react: 19.1.2
-      react-dom: 19.1.2(react@19.1.2)
-      sharp: 0.33.5
-      url: 0.11.0
-
   '@dynamic-labs/locale@4.52.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.52.2
@@ -5152,24 +4682,13 @@ snapshots:
       '@dynamic-labs/assert-package-version': 4.52.2
       '@dynamic-labs/types': 4.52.2
 
-  '@dynamic-labs/rpc-providers@4.83.1':
-    dependencies:
-      '@dynamic-labs/assert-package-version': 4.83.1
-      '@dynamic-labs/types': 4.83.1
-
   '@dynamic-labs/sdk-api-core@0.0.764': {}
 
   '@dynamic-labs/sdk-api-core@0.0.818': {}
 
   '@dynamic-labs/sdk-api-core@0.0.843': {}
 
-  '@dynamic-labs/sdk-api-core@0.0.900': {}
-
   '@dynamic-labs/sdk-api-core@0.0.927': {}
-
-  '@dynamic-labs/sdk-api-core@0.0.958': {}
-
-  '@dynamic-labs/sdk-api-core@0.0.964': {}
 
   '@dynamic-labs/sdk-react-core@4.52.2(@types/react@19.1.12)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
     dependencies:
@@ -5321,11 +4840,6 @@ snapshots:
       '@dynamic-labs/assert-package-version': 4.77.3
       '@dynamic-labs/sdk-api-core': 0.0.927
 
-  '@dynamic-labs/types@4.83.1':
-    dependencies:
-      '@dynamic-labs/assert-package-version': 4.83.1
-      '@dynamic-labs/sdk-api-core': 0.0.964
-
   '@dynamic-labs/utils@4.52.2':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.52.2
@@ -5342,16 +4856,6 @@ snapshots:
       '@dynamic-labs/logger': 4.77.3
       '@dynamic-labs/sdk-api-core': 0.0.927
       '@dynamic-labs/types': 4.77.3
-      buffer: 6.0.3
-      eventemitter3: 5.0.1
-      tldts: 6.0.16
-
-  '@dynamic-labs/utils@4.83.1':
-    dependencies:
-      '@dynamic-labs/assert-package-version': 4.83.1
-      '@dynamic-labs/logger': 4.83.1
-      '@dynamic-labs/sdk-api-core': 0.0.964
-      '@dynamic-labs/types': 4.83.1
       buffer: 6.0.3
       eventemitter3: 5.0.1
       tldts: 6.0.16
@@ -5443,18 +4947,6 @@ snapshots:
       util: 0.12.5
       zod: 4.0.5
 
-  '@dynamic-labs/wallet-book@4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
-    dependencies:
-      '@dynamic-labs/assert-package-version': 4.83.1
-      '@dynamic-labs/iconic': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      '@dynamic-labs/logger': 4.83.1
-      '@dynamic-labs/utils': 4.83.1
-      eventemitter3: 5.0.1
-      react: 19.1.2
-      react-dom: 19.1.2(react@19.1.2)
-      util: 0.12.5
-      zod: 4.0.5
-
   '@dynamic-labs/wallet-connect@4.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)':
     dependencies:
       '@dynamic-labs/assert-package-version': 4.52.2
@@ -5498,27 +4990,6 @@ snapshots:
     transitivePeerDependencies:
       - react
       - react-dom
-
-  '@dynamic-labs/wallet-connector-core@4.83.1(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@dynamic-labs-sdk/client': 0.26.9(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6)
-      '@dynamic-labs-wallet/browser-wallet-client': 0.0.337(@dynamic-labs-wallet/forward-mpc-client@0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@dynamic-labs-wallet/forward-mpc-client': 0.9.0(@dynamic-labs-wallet/primitives@0.0.337)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@dynamic-labs/assert-package-version': 4.83.1
-      '@dynamic-labs/logger': 4.83.1
-      '@dynamic-labs/rpc-providers': 4.83.1
-      '@dynamic-labs/sdk-api-core': 0.0.964
-      '@dynamic-labs/types': 4.83.1
-      '@dynamic-labs/utils': 4.83.1
-      '@dynamic-labs/wallet-book': 4.83.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
-      eventemitter3: 5.0.1
-    transitivePeerDependencies:
-      - '@dynamic-labs-wallet/primitives'
-      - bufferutil
-      - debug
-      - react
-      - react-dom
-      - utf-8-validate
 
   '@dynamic-labs/webauthn@4.52.2':
     dependencies:
@@ -6725,21 +6196,7 @@ snapshots:
 
   '@simplewebauthn/browser@13.1.0': {}
 
-  '@simplewebauthn/browser@8.3.7':
-    dependencies:
-      '@simplewebauthn/typescript-types': 8.3.4
-
-  '@simplewebauthn/browser@9.0.1':
-    dependencies:
-      '@simplewebauthn/types': 9.0.1
-
   '@simplewebauthn/types@12.0.0': {}
-
-  '@simplewebauthn/types@9.0.1': {}
-
-  '@simplewebauthn/typescript-types@8.3.4': {}
-
-  '@sindresorhus/is@4.6.0': {}
 
   '@socket.io/component-emitter@3.1.2': {}
 
@@ -6891,10 +6348,6 @@ snapshots:
   '@swc/helpers@0.5.20':
     dependencies:
       tslib: 2.8.1
-
-  '@szmarczak/http-timer@4.0.6':
-    dependencies:
-      defer-to-connect: 2.0.1
 
   '@tailwindcss/node@4.1.18':
     dependencies:
@@ -7096,13 +6549,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/cacheable-request@6.0.3':
-    dependencies:
-      '@types/http-cache-semantics': 4.2.0
-      '@types/keyv': 3.1.4
-      '@types/node': 20.19.27
-      '@types/responselike': 1.0.3
-
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 20.19.27
@@ -7113,15 +6559,9 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/http-cache-semantics@4.2.0': {}
-
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
-
-  '@types/keyv@3.1.4':
-    dependencies:
-      '@types/node': 20.19.27
 
   '@types/lodash@4.17.24': {}
 
@@ -7140,10 +6580,6 @@ snapshots:
   '@types/react@19.1.12':
     dependencies:
       csstype: 3.2.3
-
-  '@types/responselike@1.0.3':
-    dependencies:
-      '@types/node': 20.19.27
 
   '@types/trusted-types@2.0.7': {}
 
@@ -7894,32 +7330,6 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
-  '@zerodev/ecdsa-validator@5.4.9(@zerodev/sdk@5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
-    dependencies:
-      '@zerodev/sdk': 5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
-
-  '@zerodev/multi-chain-ecdsa-validator@5.4.5(@zerodev/sdk@5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(@zerodev/webauthn-key@5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)))(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
-    dependencies:
-      '@simplewebauthn/browser': 9.0.1
-      '@simplewebauthn/typescript-types': 8.3.4
-      '@zerodev/sdk': 5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      '@zerodev/webauthn-key': 5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))
-      merkletreejs: 0.3.11
-      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
-
-  '@zerodev/sdk@5.5.7(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
-    dependencies:
-      semver: 7.7.4
-      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
-
-  '@zerodev/webauthn-key@5.5.0(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5))':
-    dependencies:
-      '@noble/curves': 1.9.7
-      '@simplewebauthn/browser': 8.3.7
-      '@simplewebauthn/types': 12.0.0
-      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.5)
-
   abitype@1.0.8(typescript@5.9.3)(zod@4.3.5):
     optionalDependencies:
       typescript: 5.9.3
@@ -7934,21 +7344,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       zod: 4.3.5
-
-  ably@2.17.1(bufferutil@4.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@6.0.6):
-    dependencies:
-      '@ably/msgpack-js': 0.4.1
-      dequal: 2.0.3
-      fastestsmallesttextencoderdecoder: 1.0.22
-      got: 11.8.6
-      ulid: 2.4.0
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-    optionalDependencies:
-      react: 19.1.2
-      react-dom: 19.1.2(react@19.1.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -8086,22 +7481,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.15.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.15.2:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.9.0:
     dependencies:
       follow-redirects: 1.15.11
@@ -8124,8 +7503,6 @@ snapshots:
 
   base-x@5.0.1: {}
 
-  base64-js@1.0.2: {}
-
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.13: {}
@@ -8144,14 +7521,7 @@ snapshots:
 
   blakejs@1.2.1: {}
 
-  bn.js@4.11.6: {}
-
   bn.js@5.2.3: {}
-
-  bops@1.0.1:
-    dependencies:
-      base64-js: 1.0.2
-      to-utf8: 0.0.1
 
   borsh@0.7.0:
     dependencies:
@@ -8199,8 +7569,6 @@ snapshots:
       '@noble/hashes': 1.8.0
       bs58: 6.0.0
 
-  buffer-reverse@1.0.1: {}
-
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -8209,18 +7577,6 @@ snapshots:
   bufferutil@4.1.0:
     dependencies:
       node-gyp-build: 4.8.4
-
-  cacheable-lookup@5.0.4: {}
-
-  cacheable-request@7.0.4:
-    dependencies:
-      clone-response: 1.0.3
-      get-stream: 5.2.0
-      http-cache-semantics: 4.2.0
-      keyv: 4.5.4
-      lowercase-keys: 2.0.0
-      normalize-url: 6.1.0
-      responselike: 2.0.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -8267,10 +7623,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
-
-  clone-response@1.0.3:
-    dependencies:
-      mimic-response: 1.0.1
 
   clsx@1.2.1: {}
 
@@ -8336,8 +7688,6 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  crypto-js@4.2.0: {}
-
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
@@ -8378,15 +7728,9 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
   deep-is@0.1.4: {}
 
   deepmerge@2.2.1: {}
-
-  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -8407,8 +7751,6 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
-
-  dequal@2.0.3: {}
 
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.1.12)(react@19.1.2)):
     dependencies:
@@ -8797,21 +8139,12 @@ snapshots:
     dependencies:
       fast-safe-stringify: 2.1.1
 
-  ethereum-bloom-filters@1.2.0:
-    dependencies:
-      '@noble/hashes': 1.8.0
-
   ethereum-cryptography@2.2.1:
     dependencies:
       '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
-
-  ethjs-unit@0.1.6:
-    dependencies:
-      bn.js: 4.11.6
-      number-to-bn: 1.7.0
 
   eventemitter2@6.4.9: {}
 
@@ -8955,10 +8288,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
-
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -8985,20 +8314,6 @@ snapshots:
       gopd: 1.2.0
 
   gopd@1.2.0: {}
-
-  got@11.8.6:
-    dependencies:
-      '@sindresorhus/is': 4.6.0
-      '@szmarczak/http-timer': 4.0.6
-      '@types/cacheable-request': 6.0.3
-      '@types/responselike': 1.0.3
-      cacheable-lookup: 5.0.4
-      cacheable-request: 7.0.4
-      decompress-response: 6.0.0
-      http2-wrapper: 1.0.3
-      lowercase-keys: 2.0.0
-      p-cancelable: 2.1.1
-      responselike: 2.0.1
 
   gql.tada@1.9.1(graphql@16.13.2)(typescript@5.9.3):
     dependencies:
@@ -9066,8 +8381,6 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
-  http-cache-semantics@4.2.0: {}
-
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -9075,11 +8388,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
-
-  http2-wrapper@1.0.3:
-    dependencies:
-      quick-lru: 5.1.1
-      resolve-alpn: 1.2.1
 
   humanize-ms@1.2.1:
     dependencies:
@@ -9191,8 +8499,6 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
-  is-hex-prefixed@1.0.0: {}
-
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -9270,10 +8576,6 @@ snapshots:
   isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-
-  isows@1.0.7(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
-    dependencies:
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -9429,8 +8731,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lowercase-keys@2.0.0: {}
-
   lru-cache@11.2.7: {}
 
   lucide-react@0.487.0(react@19.1.2):
@@ -9445,14 +8745,6 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  merkletreejs@0.3.11:
-    dependencies:
-      bignumber.js: 9.3.1
-      buffer-reverse: 1.0.1
-      crypto-js: 4.2.0
-      treeify: 1.1.0
-      web3-utils: 1.10.4
-
   micro-ftch@0.3.1: {}
 
   micromatch@4.0.8:
@@ -9465,10 +8757,6 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mimic-response@1.0.1: {}
-
-  mimic-response@3.1.0: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -9535,13 +8823,6 @@ snapshots:
   node-releases@2.0.36: {}
 
   normalize-path@3.0.0: {}
-
-  normalize-url@6.1.0: {}
-
-  number-to-bn@1.7.0:
-    dependencies:
-      bn.js: 4.11.6
-      strip-hex-prefix: 1.0.0
 
   obj-multiplex@1.0.0:
     dependencies:
@@ -9697,8 +8978,6 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  p-cancelable@2.1.1: {}
-
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -9798,14 +9077,10 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
-  proxy-from-env@2.1.0: {}
-
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-
-  punycode@1.3.2: {}
 
   punycode@2.3.1: {}
 
@@ -9830,19 +9105,11 @@ snapshots:
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
 
-  querystring@0.2.0: {}
-
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
 
-  quick-lru@5.1.1: {}
-
   radix3@1.1.2: {}
-
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   react-clientside-effect@1.2.8(react@19.1.2):
     dependencies:
@@ -9956,8 +9223,6 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
-  resolve-alpn@1.2.1: {}
-
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -9976,10 +9241,6 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  responselike@2.0.1:
-    dependencies:
-      lowercase-keys: 2.0.0
 
   reusify@1.1.0: {}
 
@@ -10272,10 +9533,6 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-hex-prefix@1.0.0:
-    dependencies:
-      is-hex-prefixed: 1.0.0
-
   strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(react@19.1.2):
@@ -10322,15 +9579,11 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  to-utf8@0.0.1: {}
-
   toidentifier@1.0.1: {}
 
   toposort@2.0.2: {}
 
   tr46@0.0.3: {}
-
-  treeify@1.1.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -10400,8 +9653,6 @@ snapshots:
     dependencies:
       multiformats: 9.9.0
 
-  ulid@2.4.0: {}
-
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -10460,11 +9711,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url@0.11.0:
-    dependencies:
-      punycode: 1.3.2
-      querystring: 0.2.0
-
   use-callback-ref@1.3.3(@types/react@19.1.12)(react@19.1.2):
     dependencies:
       react: 19.1.2
@@ -10492,8 +9738,6 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
     optional: true
-
-  utf8@3.0.0: {}
 
   util-deprecate@1.0.2: {}
 
@@ -10608,17 +9852,6 @@ snapshots:
       - zod
 
   void-elements@3.1.0: {}
-
-  web3-utils@1.10.4:
-    dependencies:
-      '@ethereumjs/util': 8.1.0
-      bn.js: 5.2.3
-      ethereum-bloom-filters: 1.2.0
-      ethereum-cryptography: 2.2.1
-      ethjs-unit: 0.1.6
-      number-to-bn: 1.7.0
-      randombytes: 2.1.0
-      utf8: 3.0.0
 
   webextension-polyfill@0.10.0: {}
 

--- a/examples/nextjs-iron-ramp/src/app/api/offramp/route.ts
+++ b/examples/nextjs-iron-ramp/src/app/api/offramp/route.ts
@@ -27,6 +27,7 @@ const quoteSchema = z.object({
   source_amount: z.number().positive().optional(),
   destination_amount: z.number().positive().optional(),
   bank_account_id: z.string().min(1, "Bank account ID (IBAN) is required"),
+  bank_id: z.string().optional(),
   blockchain: z.enum(["Ethereum", "Solana", "Polygon", "Arbitrum", "Base", "Stellar", "Citrea"]).optional(),
 });
 
@@ -35,6 +36,7 @@ const executeSchema = z.object({
   quote_id: z.string().min(1, "Quote ID is required"),
   customer_id: z.string().min(1, "Customer ID is required"),
   bank_account_id: z.string().min(1, "Bank account ID (IBAN) is required"),
+  bank_id: z.string().optional(),
   blockchain: z.enum(["Ethereum", "Solana", "Polygon", "Arbitrum", "Base", "Stellar", "Citrea"]).optional(),
   source_currency: z.enum(["USDC", "USDT", "USDB", "EURC"]).optional(),
   destination_currency: z.enum(["USD", "EUR", "GBP", "BRL", "MXN"]).optional(),
@@ -65,7 +67,8 @@ export async function POST(req: NextRequest) {
         source_amount: validated.source_amount,
         destination_amount: validated.destination_amount,
         bank_account_id: validated.bank_account_id,
-        blockchain: validated.blockchain, // Pass blockchain selection
+        bank_id: validated.bank_id,
+        blockchain: validated.blockchain,
       };
 
       const quote = await ironClient.getOfframpQuote(quoteRequest);
@@ -76,9 +79,10 @@ export async function POST(req: NextRequest) {
         quote_id: validated.quote_id,
         customer_id: validated.customer_id,
         bank_account_id: validated.bank_account_id,
-        blockchain: validated.blockchain, // Pass blockchain selection
-        source_currency: validated.source_currency, // Pass source currency
-        destination_currency: validated.destination_currency, // Pass destination currency
+        bank_id: validated.bank_id,
+        blockchain: validated.blockchain,
+        source_currency: validated.source_currency,
+        destination_currency: validated.destination_currency,
       };
 
       const offramp = await ironClient.createOfframp(offrampRequest);

--- a/examples/nextjs-iron-ramp/src/app/api/onramp/route.ts
+++ b/examples/nextjs-iron-ramp/src/app/api/onramp/route.ts
@@ -28,6 +28,7 @@ const quoteSchema = z.object({
   destination_amount: z.number().positive().optional(),
   payment_rail: z.enum(["ach", "wire", "sepa", "pix", "faster_payments"]),
   wallet_address: z.string().min(1, "Wallet address is required"),
+  wallet_id: z.string().optional(),
   blockchain: z.enum(["Ethereum", "Solana", "Polygon", "Arbitrum", "Base", "Stellar", "Citrea"]).optional(),
 });
 
@@ -36,6 +37,7 @@ const executeSchema = z.object({
   quote_id: z.string().min(1, "Quote ID is required"),
   customer_id: z.string().min(1, "Customer ID is required"),
   wallet_address: z.string().min(1, "Wallet address is required"),
+  wallet_id: z.string().optional(),
   bank_account_id: z.string().optional(),
   blockchain: z.enum(["Ethereum", "Solana", "Polygon", "Arbitrum", "Base", "Stellar", "Citrea"]).optional(),
   source_currency: z.enum(["USD", "EUR", "GBP", "BRL", "MXN"]).optional(),
@@ -68,6 +70,7 @@ export async function POST(req: NextRequest) {
         destination_amount: validated.destination_amount,
         payment_rail: validated.payment_rail,
         wallet_address: validated.wallet_address,
+        wallet_id: validated.wallet_id,
         blockchain: validated.blockchain,
       };
 
@@ -79,10 +82,11 @@ export async function POST(req: NextRequest) {
         quote_id: validated.quote_id,
         customer_id: validated.customer_id,
         wallet_address: validated.wallet_address,
+        wallet_id: validated.wallet_id,
         bank_account_id: validated.bank_account_id,
-        blockchain: validated.blockchain, // Pass blockchain selection
-        source_currency: validated.source_currency, // Pass source currency
-        destination_currency: validated.destination_currency, // Pass destination currency
+        blockchain: validated.blockchain,
+        source_currency: validated.source_currency,
+        destination_currency: validated.destination_currency,
       };
 
       const onramp = await ironClient.createOnramp(onrampRequest);

--- a/examples/nextjs-iron-ramp/src/app/onboard/page.tsx
+++ b/examples/nextjs-iron-ramp/src/app/onboard/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useDynamicContext } from "@dynamic-labs/sdk-react-core";
-import { useState, useCallback } from "react";
+import { useDynamicContext, useUserWallets, useSwitchWallet } from "@dynamic-labs/sdk-react-core";
+import { useState, useEffect, useCallback } from "react";
 import { config } from "@/lib/config";
-import { CheckCircle2, Loader2, RotateCcw } from "lucide-react";
+import { ArrowRight, CheckCircle2, Loader2, RotateCcw } from "lucide-react";
 import { useKYCMetadata, type OnboardStep } from "@/lib/hooks/useKYCMetadata";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -28,10 +28,26 @@ const STEPS: { key: OnboardStep; label: string }[] = [
   { key: "complete", label: "Done" },
 ];
 
+function getNetworkLabel(address: string, chain?: string | number | null): string {
+  if (!address.startsWith("0x")) return "Solana";
+  if (!chain || chain === "EVM") return "EVM";
+  const n = parseInt(String(chain));
+  switch (n) {
+    case 1: return "Ethereum";
+    case 137: return "Polygon";
+    case 42161: return "Arbitrum";
+    case 8453: return "Base";
+    default: return "EVM";
+  }
+}
+
 export default function OnboardPage() {
   const { user, primaryWallet } = useDynamicContext();
+  const userWallets = useUserWallets();
+  const switchWallet = useSwitchWallet();
   const {
     customerId,
+    walletAddress: metaWalletAddress,
     identificationId,
     kycUrl,
     step,
@@ -43,6 +59,9 @@ export default function OnboardPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [requiredSignings, setRequiredSignings] = useState<RequiredSigning[]>([]);
+  const [linkedWalletAddresses, setLinkedWalletAddresses] = useState<string[]>([]);
+  const [fetchingWallets, setFetchingWallets] = useState(false);
+  const [linkingWallet, setLinkingWallet] = useState<string | null>(null);
   const isSandbox =
     process.env.NEXT_PUBLIC_IRON_ENVIRONMENT === "sandbox" ||
     !process.env.NEXT_PUBLIC_IRON_ENVIRONMENT;
@@ -282,33 +301,71 @@ export default function OnboardPage() {
     }
   };
 
-  const handleCreateWallet = async () => {
-    setLoading(true);
+  const fetchRegisteredWallets = useCallback(async () => {
+    if (!customerId) return;
+    setFetchingWallets(true);
+    try {
+      const res = await fetch(
+        `${config.api.baseUrl}/api/iron/customers/${customerId}/wallets`
+      );
+      if (res.ok) {
+        const data = await res.json();
+        const wallets: Array<{ address?: string; wallet_address?: string }> =
+          data.data?.data || data.data || [];
+        setLinkedWalletAddresses(
+          wallets.map((w) => w.address || w.wallet_address || "").filter(Boolean)
+        );
+      }
+    } catch {
+      /* silent — we'll just show no linked state */
+    } finally {
+      setFetchingWallets(false);
+    }
+  }, [customerId]);
+
+  useEffect(() => {
+    if (step === "wallet" && customerId) {
+      fetchRegisteredWallets();
+    }
+  }, [step, customerId, fetchRegisteredWallets]);
+
+  const handleLinkWallet = async (wallet: (typeof userWallets)[number]) => {
+    setLinkingWallet(wallet.address);
     setError("");
     try {
-      if (!primaryWallet) throw new Error("No wallet connected.");
-      let walletAddress = primaryWallet.address;
+      let walletAddress = wallet.address;
       if (!walletAddress) throw new Error("Unable to get wallet address");
-      walletAddress = walletAddress.toLowerCase();
 
-      const chainId = primaryWallet.chain;
+      const chainId = wallet.chain;
+      const isSolanaWallet = !walletAddress.startsWith("0x");
       let blockchain = "Base";
-      if (chainId && chainId !== "EVM") {
-        const n = typeof chainId === "string" ? parseInt(chainId) : chainId;
-        if (!isNaN(n)) {
-          switch (n) {
-            case 1: blockchain = "Ethereum"; break;
-            case 137: blockchain = "Polygon"; break;
-            case 42161: blockchain = "Arbitrum"; break;
-            case 8453: blockchain = "Base"; break;
+
+      if (isSolanaWallet) {
+        blockchain = "Solana";
+      } else {
+        walletAddress = walletAddress.toLowerCase();
+        if (chainId && chainId !== "EVM") {
+          const n = typeof chainId === "string" ? parseInt(chainId) : chainId;
+          if (!isNaN(n)) {
+            switch (n) {
+              case 1: blockchain = "Ethereum"; break;
+              case 137: blockchain = "Polygon"; break;
+              case 42161: blockchain = "Arbitrum"; break;
+              case 8453: blockchain = "Base"; break;
+            }
           }
         }
+      }
+
+      // Make this wallet primary in Dynamic before signing so the prompt appears on the right wallet
+      if (wallet.id !== primaryWallet?.id) {
+        await switchWallet(wallet.id);
       }
 
       const now = new Date();
       const dateStr = `${now.getUTCDate().toString().padStart(2, "0")}/${(now.getUTCMonth() + 1).toString().padStart(2, "0")}/${now.getUTCFullYear()}`;
       const proofMessage = `I am verifying ownership of the wallet address ${walletAddress} as customer ${customerId}. This message was signed on ${dateStr} to confirm my control over this wallet.`;
-      const signature = await primaryWallet.signMessage(proofMessage);
+      const signature = await wallet.signMessage(proofMessage);
       if (!signature) throw new Error("Failed to sign message");
 
       const walletPayload = {
@@ -319,7 +376,7 @@ export default function OnboardPage() {
         signature,
       };
 
-      // Retry up to 6 times (12s total) — Iron activates customers async after signing.
+      let linkedId = "";
       let lastMsg = "";
       for (let attempt = 0; attempt < 6; attempt++) {
         if (attempt > 0) await new Promise((r) => setTimeout(r, 2000));
@@ -337,7 +394,6 @@ export default function OnboardPage() {
           if (lastMsg.includes("not active") || lastMsg.includes("Customer is not active")) {
             throw new Error("Your account is still being activated by Iron Finance. Please wait a moment and try again.");
           }
-          // Wallet already registered — look up the existing one and advance.
           const isAlreadyRegistered =
             lastMsg.toLowerCase().includes("already") ||
             lastMsg.toLowerCase().includes("duplicate") ||
@@ -350,26 +406,41 @@ export default function OnboardPage() {
             if (walletsRes.ok) {
               const walletsData = await walletsRes.json();
               const existing = (walletsData.data?.data || walletsData.data || []).find(
-                (w: { address?: string; wallet_address?: string }) =>
-                  (w.address || w.wallet_address)?.toLowerCase() === walletAddress
+                (w: { address?: string; wallet_address?: string; id?: string }) => {
+                  const addr = w.address || w.wallet_address || "";
+                  return isSolanaWallet ? addr === walletAddress : addr.toLowerCase() === walletAddress;
+                }
               );
               if (existing?.id) {
-                await updateState({ walletId: existing.id, walletAddress, step: "bank" });
-                return;
+                linkedId = existing.id;
+                break;
               }
             }
           }
-          throw new Error(lastMsg || "Failed to register wallet");
+          if (!linkedId) throw new Error(lastMsg || "Failed to register wallet");
+          break;
         }
         const result = await res.json();
-        await updateState({ walletId: result.data.id, walletAddress, step: "bank" });
+        linkedId = result.data.id;
         break;
       }
+
+      if (!linkedId) throw new Error("Failed to register wallet");
+
+      // Store this wallet as primary in metadata if none is stored yet
+      if (!metaWalletAddress) {
+        await updateState({ walletId: linkedId, walletAddress });
+      }
+      setLinkedWalletAddresses((prev) => [...new Set([...prev, walletAddress])]);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to register wallet");
     } finally {
-      setLoading(false);
+      setLinkingWallet(null);
     }
+  };
+
+  const handleContinueFromWallet = async () => {
+    await updateState({ step: "bank" });
   };
 
   const handleAddBankAccount = async () => {
@@ -407,6 +478,36 @@ export default function OnboardPage() {
           }
           if (msg.includes("not active") || msg.includes("Customer is not active")) {
             throw new Error("Your account is still being activated by Iron Finance. Please wait a moment and try again.");
+          }
+          // Bank already registered — look up the existing account and advance
+          const isAlreadyRegistered =
+            res.status === 409 ||
+            msg.toLowerCase().includes("already") ||
+            msg.toLowerCase().includes("duplicate") ||
+            msg.toLowerCase().includes("exists");
+          if (isAlreadyRegistered) {
+            const banksRes = await fetch(
+              `${config.api.baseUrl}/api/iron/customers/${customerId}/banks`
+            );
+            if (banksRes.ok) {
+              const banksData = await banksRes.json();
+              const normalizeIban = (s: string) => s.replace(/\s/g, "").toUpperCase();
+              const existing = (banksData.data?.data || banksData.data || []).find(
+                (b: { id?: string; iban?: string; account_identifier?: { iban?: string } }) => {
+                  const bIban = b.iban || b.account_identifier?.iban || "";
+                  return normalizeIban(bIban) === normalizeIban(bankData.iban);
+                }
+              );
+              if (existing?.id) {
+                await updateState({
+                  bankAccountId: existing.id,
+                  bankIban: bankData.iban,
+                  step: "complete",
+                  kycCompleted: true,
+                });
+                return;
+              }
+            }
           }
           throw new Error(msg || "Failed to add bank account");
         }
@@ -669,24 +770,85 @@ export default function OnboardPage() {
       {step === "wallet" && (
         <Card>
           <CardHeader>
-            <CardTitle>Register Wallet</CardTitle>
+            <CardTitle>Register Wallet(s)</CardTitle>
             <CardDescription>
-              Link your embedded wallet to your Iron Finance account.
+              Link one or more wallets to your Iron Finance account. You need at least one to continue.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <p className="text-sm text-muted-foreground">
-              Your wallet address:{" "}
-              <span className="font-mono text-foreground">
-                {primaryWallet?.address
-                  ? `${primaryWallet.address.slice(0, 6)}...${primaryWallet.address.slice(-4)}`
-                  : "Not connected"}
-              </span>
-            </p>
-            <Button className="w-full" onClick={handleCreateWallet} disabled={loading || !primaryWallet}>
-              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Register Wallet
-            </Button>
+            {fetchingWallets ? (
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span className="text-sm">Checking linked wallets…</span>
+              </div>
+            ) : userWallets.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No wallets connected. Connect a wallet to continue.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {userWallets.map((w) => {
+                  const isSol = !w.address.startsWith("0x");
+                  const networkLabel = getNetworkLabel(w.address, w.chain);
+                  const isLinked = linkedWalletAddresses.some((linked) =>
+                    isSol ? linked === w.address : linked.toLowerCase() === w.address.toLowerCase()
+                  );
+                  const isLinking = linkingWallet === w.address;
+                  return (
+                    <div
+                      key={w.address}
+                      className="flex items-center justify-between rounded-lg border px-4 py-3"
+                    >
+                      <div className="flex items-center gap-3">
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                            isSol
+                              ? "bg-purple-500/10 text-purple-600"
+                              : "bg-blue-500/10 text-blue-600"
+                          }`}
+                        >
+                          {isSol ? "SOL" : "EVM"}
+                        </span>
+                        <div>
+                          <p className="text-sm font-mono">
+                            {w.address.slice(0, 6)}…{w.address.slice(-4)}
+                          </p>
+                          <p className="text-xs text-muted-foreground">{networkLabel}</p>
+                        </div>
+                      </div>
+                      {isLinked ? (
+                        <div className="flex items-center gap-1.5 text-green-600">
+                          <CheckCircle2 className="h-4 w-4" />
+                          <span className="text-xs font-medium">Linked</span>
+                        </div>
+                      ) : (
+                        <Button
+                          size="sm"
+                          onClick={() => handleLinkWallet(w)}
+                          disabled={!!linkingWallet}
+                        >
+                          {isLinking && <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />}
+                          Link
+                        </Button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {linkedWalletAddresses.length > 0 ? (
+              <Button className="w-full" onClick={handleContinueFromWallet} disabled={loading}>
+                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Continue <ArrowRight className="ml-2 h-4 w-4" />
+              </Button>
+            ) : (
+              !fetchingWallets && userWallets.length > 0 && (
+                <p className="text-center text-xs text-muted-foreground">
+                  Link at least one wallet to continue.
+                </p>
+              )
+            )}
           </CardContent>
         </Card>
       )}

--- a/examples/nextjs-iron-ramp/src/components/RampInterface.tsx
+++ b/examples/nextjs-iron-ramp/src/components/RampInterface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useDynamicContext, DynamicWidget } from "@dynamic-labs/sdk-react-core";
+import { useDynamicContext, DynamicWidget, useUserWallets, useSwitchWallet } from "@dynamic-labs/sdk-react-core";
 import { useState, useEffect, useCallback } from "react";
 import { config } from "@/lib/config";
 import { useKYCMetadata } from "@/lib/hooks/useKYCMetadata";
@@ -105,7 +105,9 @@ const ONBOARD_STEPS = [
 ];
 
 export function RampInterface() {
-  const { user } = useDynamicContext();
+  const { user, primaryWallet } = useDynamicContext();
+  const userWallets = useUserWallets();
+  const switchWallet = useSwitchWallet();
   const {
     customerId: metaCustomerId,
     step: onboardingStep,
@@ -150,6 +152,8 @@ export function RampInterface() {
 
   const [transactions, setTransactions] = useState<AutoRamp[]>([]);
   const [loadingTransactions, setLoadingTransactions] = useState(false);
+  const [showLinkMore, setShowLinkMore] = useState(false);
+  const [linkingExtra, setLinkingExtra] = useState<string | null>(null);
   const [selectedTx, setSelectedTx] = useState<AutoRamp | null>(null);
 
   useEffect(() => {
@@ -232,12 +236,59 @@ export function RampInterface() {
     if (customerId) fetchRegisteredAccounts();
   }, [customerId, fetchRegisteredAccounts]);
 
+  const handleLinkAdditionalWallet = useCallback(async (wallet: (typeof userWallets)[number]) => {
+    setLinkingExtra(wallet.address);
+    setError("");
+    try {
+      let addr = wallet.address;
+      const isSol = !addr.startsWith("0x");
+      let blockchain = "Base";
+      if (isSol) {
+        blockchain = "Solana";
+      } else {
+        addr = addr.toLowerCase();
+        const chain = wallet.chain;
+        if (chain && chain !== "EVM") {
+          const n = parseInt(String(chain));
+          switch (n) {
+            case 1: blockchain = "Ethereum"; break;
+            case 137: blockchain = "Polygon"; break;
+            case 42161: blockchain = "Arbitrum"; break;
+            case 8453: blockchain = "Base"; break;
+          }
+        }
+      }
+      if (wallet.id !== primaryWallet?.id) await switchWallet(wallet.id);
+      const now = new Date();
+      const dateStr = `${now.getUTCDate().toString().padStart(2, "0")}/${(now.getUTCMonth() + 1).toString().padStart(2, "0")}/${now.getUTCFullYear()}`;
+      const msg = `I am verifying ownership of the wallet address ${addr} as customer ${customerId}. This message was signed on ${dateStr} to confirm my control over this wallet.`;
+      const sig = await wallet.signMessage(msg);
+      if (!sig) throw new Error("Failed to sign message");
+      const res = await fetch(`${config.api.baseUrl}/api/iron/wallets/self-hosted`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ customer_id: customerId, blockchain, address: addr, message: msg, signature: sig }),
+      });
+      if (!res.ok) {
+        const ed = await res.json().catch(() => ({}));
+        throw new Error(ed.error || "Failed to link wallet");
+      }
+      await fetchRegisteredAccounts();
+      setShowLinkMore(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to link wallet");
+    } finally {
+      setLinkingExtra(null);
+    }
+  }, [customerId, primaryWallet, switchWallet, fetchRegisteredAccounts]);
+
   useEffect(() => {
     if (registeredWallets.length > 0 && selectedWalletIndex === null) {
       const i = metaWalletAddress
-        ? registeredWallets.findIndex(
-            (w) =>
-              w.address.toLowerCase() === metaWalletAddress.toLowerCase()
+        ? registeredWallets.findIndex((w) =>
+            metaWalletAddress.startsWith("0x")
+              ? w.address.toLowerCase() === metaWalletAddress.toLowerCase()
+              : w.address === metaWalletAddress
           )
         : 0;
       const idx = i >= 0 ? i : 0;
@@ -353,6 +404,7 @@ export function RampInterface() {
               source_amount: parseFloat(amount) * 100,
               payment_rail: "sepa" as const,
               wallet_address: selectedWalletAddr,
+              wallet_id: selectedWallet?.id,
               blockchain: selectedChain,
             }
           : {
@@ -362,6 +414,7 @@ export function RampInterface() {
               destination_currency: selectedFiatCurrency,
               source_amount: parseFloat(amount) * 1000000,
               bank_account_id: selectedIban,
+              bank_id: selectedBank?.id,
               blockchain: selectedChain,
             };
 
@@ -420,6 +473,7 @@ export function RampInterface() {
               quote_id: quote.id || quote.data?.id,
               customer_id: customerId,
               wallet_address: selectedWalletAddr,
+              wallet_id: selectedWallet?.id,
               blockchain: selectedChain,
               source_currency: selectedFiatCurrency,
               destination_currency: selectedToken,
@@ -429,6 +483,7 @@ export function RampInterface() {
               quote_id: quote.id || quote.data?.id,
               customer_id: customerId,
               bank_account_id: selectedIban,
+              bank_id: selectedBank?.id,
               blockchain: selectedChain,
               source_currency: selectedToken,
               destination_currency: selectedFiatCurrency,
@@ -510,30 +565,102 @@ export function RampInterface() {
               </div>
               <div className="grid grid-cols-2 gap-4 pt-2 border-t text-sm">
                 <div>
-                  <p className="text-muted-foreground text-xs uppercase tracking-wide mb-1">
-                    Wallet
+                  <p className="text-muted-foreground text-xs uppercase tracking-wide mb-2">
+                    Linked Wallets
                   </p>
-                  <div className="flex items-center gap-1">
-                    <p className="font-mono text-xs">
-                      {metaWalletAddress
-                        ? `${metaWalletAddress.slice(0, 8)}...${metaWalletAddress.slice(-6)}`
-                        : "—"}
-                    </p>
-                    {metaWalletAddress && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-5 w-5"
-                        onClick={() => handleCopy(metaWalletAddress, "wallet-addr")}
-                      >
-                        {copiedField === "wallet-addr" ? (
-                          <Check className="h-3 w-3 text-green-500" />
+                  {registeredWallets.length > 0 ? (
+                    <div className="space-y-1.5">
+                      {registeredWallets.map((w, i) => {
+                        const isSol = !w.address.startsWith("0x");
+                        return (
+                          <div key={w.id} className="flex items-center gap-1.5">
+                            <span className={`rounded-full px-1.5 py-0 text-[10px] font-semibold ${
+                              isSol ? "bg-purple-500/10 text-purple-600" : "bg-blue-500/10 text-blue-600"
+                            }`}>
+                              {isSol ? "SOL" : "EVM"}
+                            </span>
+                            <p className="font-mono text-xs">
+                              {w.address.slice(0, 6)}…{w.address.slice(-4)}
+                            </p>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-5 w-5"
+                              onClick={() => handleCopy(w.address, `wallet-${i}`)}
+                            >
+                              {copiedField === `wallet-${i}` ? (
+                                <Check className="h-3 w-3 text-green-500" />
+                              ) : (
+                                <Copy className="h-3 w-3" />
+                              )}
+                            </Button>
+                          </div>
+                        );
+                      })}
+                      {/* Unlinked wallets — offer to link them */}
+                      {(() => {
+                        const unlinked = userWallets.filter(
+                          (uw) => !registeredWallets.some((rw) =>
+                            uw.address.startsWith("0x")
+                              ? rw.address.toLowerCase() === uw.address.toLowerCase()
+                              : rw.address === uw.address
+                          )
+                        );
+                        if (unlinked.length === 0) return null;
+                        return showLinkMore ? (
+                          <div className="mt-1 space-y-1.5">
+                            {unlinked.map((uw) => {
+                              const isSol = !uw.address.startsWith("0x");
+                              const isLinking = linkingExtra === uw.address;
+                              return (
+                                <div key={uw.address} className="flex items-center justify-between rounded-md border px-3 py-2">
+                                  <div className="flex items-center gap-2">
+                                    <span className={`rounded-full px-1.5 py-0 text-[10px] font-semibold ${isSol ? "bg-purple-500/10 text-purple-600" : "bg-blue-500/10 text-blue-600"}`}>
+                                      {isSol ? "SOL" : "EVM"}
+                                    </span>
+                                    <span className="font-mono text-xs">{uw.address.slice(0, 6)}…{uw.address.slice(-4)}</span>
+                                  </div>
+                                  <Button size="sm" onClick={() => handleLinkAdditionalWallet(uw)} disabled={!!linkingExtra}>
+                                    {isLinking && <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />}
+                                    Link
+                                  </Button>
+                                </div>
+                              );
+                            })}
+                            <button className="text-xs text-muted-foreground hover:underline" onClick={() => setShowLinkMore(false)}>
+                              Cancel
+                            </button>
+                          </div>
                         ) : (
-                          <Copy className="h-3 w-3" />
-                        )}
-                      </Button>
-                    )}
-                  </div>
+                          <button className="mt-0.5 text-xs text-primary hover:underline cursor-pointer" onClick={() => setShowLinkMore(true)}>
+                            + Link another wallet
+                          </button>
+                        );
+                      })()}
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-1">
+                      <p className="font-mono text-xs">
+                        {metaWalletAddress
+                          ? `${metaWalletAddress.slice(0, 6)}…${metaWalletAddress.slice(-4)}`
+                          : "—"}
+                      </p>
+                      {metaWalletAddress && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-5 w-5"
+                          onClick={() => handleCopy(metaWalletAddress, "wallet-addr")}
+                        >
+                          {copiedField === "wallet-addr" ? (
+                            <Check className="h-3 w-3 text-green-500" />
+                          ) : (
+                            <Copy className="h-3 w-3" />
+                          )}
+                        </Button>
+                      )}
+                    </div>
+                  )}
                 </div>
                 <div>
                   <p className="text-muted-foreground text-xs uppercase tracking-wide mb-1">
@@ -672,7 +799,16 @@ export function RampInterface() {
                             <SelectValue placeholder="Select chain" />
                           </SelectTrigger>
                           <SelectContent>
-                            {CHAINS.map((c) => (
+                            {(registeredWallets.length > 0
+                              ? (() => {
+                                  const hasEVM = registeredWallets.some((w) => w.blockchain !== "Solana");
+                                  const hasSolana = registeredWallets.some((w) => w.blockchain === "Solana");
+                                  return CHAINS.filter((c) =>
+                                    c.id === "Solana" ? hasSolana : hasEVM
+                                  );
+                                })()
+                              : CHAINS
+                            ).map((c) => (
                               <SelectItem key={c.id} value={c.id}>
                                 {c.name}
                               </SelectItem>
@@ -747,10 +883,17 @@ export function RampInterface() {
                             onValueChange={(v) => {
                               const idx = parseInt(v);
                               setSelectedWalletIndex(idx);
-                              setWalletAddress(registeredWallets[idx]?.address || "");
+                              const addr = registeredWallets[idx]?.address || "";
+                              setWalletAddress(addr);
                               if (registeredWallets[idx]?.blockchain) {
                                 setSelectedChain(registeredWallets[idx].blockchain);
                               }
+                              // Switch the Dynamic primary wallet to match the selected registered wallet
+                              const isSol = addr && !addr.startsWith("0x");
+                              const match = userWallets.find((dw) =>
+                                isSol ? dw.address === addr : dw.address.toLowerCase() === addr.toLowerCase()
+                              );
+                              if (match) switchWallet(match.id);
                             }}
                             disabled={loadingAccounts}
                           >
@@ -771,7 +914,7 @@ export function RampInterface() {
                           <Input
                             value={walletAddress}
                             onChange={(e) => setWalletAddress(e.target.value)}
-                            placeholder="0x..."
+                            placeholder="0x... or Solana address"
                           />
                         )}
                       </div>

--- a/examples/nextjs-iron-ramp/src/constants/ramp.ts
+++ b/examples/nextjs-iron-ramp/src/constants/ramp.ts
@@ -9,6 +9,7 @@ export const CHAINS: Chain[] = [
   { id: "Ethereum", name: "Ethereum" },
   { id: "Base", name: "Base" },
   { id: "Polygon", name: "Polygon" },
+  { id: "Solana", name: "Solana" },
 ];
 
 export const TOKENS: Token[] = [

--- a/examples/nextjs-iron-ramp/src/lib/hooks/useKYCMetadata.ts
+++ b/examples/nextjs-iron-ramp/src/lib/hooks/useKYCMetadata.ts
@@ -115,33 +115,38 @@ export function useKYCMetadata() {
         return true;
       }
 
-      try {
-        const metadata: IronKYCMetadata = {
-          ...(user.metadata as IronKYCMetadata),
-          iron: {
-            customerId: newState.customerId,
-            walletId: newState.walletId,
-            walletAddress: newState.walletAddress,
-            bankAccountId: newState.bankAccountId,
-            bankIban: newState.bankIban,
-            identificationId: newState.identificationId,
-            kycUrl: newState.kycUrl,
-            onboardingStep: newState.step,
-            kycCompleted: newState.kycCompleted,
-            updatedAt: new Date().toISOString(),
-            createdAt:
-              (user.metadata as IronKYCMetadata)?.iron?.createdAt ||
-              new Date().toISOString(),
-          },
-        };
+      const metadata: IronKYCMetadata = {
+        ...(user.metadata as IronKYCMetadata),
+        iron: {
+          customerId: newState.customerId,
+          walletId: newState.walletId,
+          walletAddress: newState.walletAddress,
+          bankAccountId: newState.bankAccountId,
+          bankIban: newState.bankIban,
+          identificationId: newState.identificationId,
+          kycUrl: newState.kycUrl,
+          onboardingStep: newState.step,
+          kycCompleted: newState.kycCompleted,
+          updatedAt: new Date().toISOString(),
+          createdAt:
+            (user.metadata as IronKYCMetadata)?.iron?.createdAt ||
+            new Date().toISOString(),
+        },
+      };
 
-        await updateUser({ metadata });
-        lastSyncedState.current = stateHash;
-        return true;
-      } catch (e) {
-        console.error("[useKYCMetadata] Sync failed:", e instanceof Error ? e.message : e);
-        return false;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          if (attempt > 0) await new Promise((r) => setTimeout(r, attempt * 1000));
+          await updateUser({ metadata });
+          lastSyncedState.current = stateHash;
+          return true;
+        } catch (e) {
+          if (attempt === 2) {
+            console.warn("[useKYCMetadata] Sync failed after retries:", e instanceof Error ? e.message : e);
+          }
+        }
       }
+      return false;
     },
     [user, updateUser]
   );

--- a/examples/nextjs-iron-ramp/src/lib/providers.tsx
+++ b/examples/nextjs-iron-ramp/src/lib/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { EthereumWalletConnectors } from "@dynamic-labs/ethereum";
+import { SolanaWalletConnectors } from "@dynamic-labs/solana";
 import { DynamicContextProvider } from "@dynamic-labs/sdk-react-core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { config } from "./config";
@@ -20,7 +21,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       theme="light"
       settings={{
         environmentId: config.dynamic.environmentId,
-        walletConnectors: [EthereumWalletConnectors],
+        walletConnectors: [EthereumWalletConnectors, SolanaWalletConnectors],
       }}
     >
       <QueryClientProvider client={queryClient}>

--- a/examples/nextjs-iron-ramp/src/lib/services/iron.ts
+++ b/examples/nextjs-iron-ramp/src/lib/services/iron.ts
@@ -253,7 +253,8 @@ export interface OnrampQuoteRequest {
   source_amount?: number; // Amount in cents
   destination_amount?: number; // Amount in smallest unit
   payment_rail: PaymentRail;
-  wallet_address: string; // The blockchain address (e.g., 0x...) — must match registered wallet's chain
+  wallet_address: string; // The blockchain address (EVM 0x... or Solana base58) — must match registered wallet's chain
+  wallet_id?: string; // Iron Finance registered wallet ID — preferred over wallet_address when available
   blockchain?: BlockchainType; // The blockchain to use for the destination currency
 }
 
@@ -264,6 +265,7 @@ export interface OfframpQuoteRequest {
   source_amount?: number; // Amount in smallest unit
   destination_amount?: number; // Amount in cents
   bank_account_id: string; // The bank IBAN for receiving fiat
+  bank_id?: string; // Iron Finance registered bank account ID — preferred over IBAN when available
   blockchain?: BlockchainType; // The blockchain to use for the source currency
 }
 
@@ -382,7 +384,8 @@ export interface IronAutorampResponse {
 export interface CreateOnrampRequest {
   quote_id: string;
   customer_id: string;
-  wallet_address: string; // The actual blockchain wallet address (e.g., 0x...)
+  wallet_address: string; // The actual blockchain wallet address (EVM 0x... or Solana base58)
+  wallet_id?: string; // Iron Finance registered wallet ID — preferred over wallet_address when available
   bank_account_id?: string; // Optional if using virtual account
   blockchain?: BlockchainType; // The blockchain to use
   source_currency?: FiatCurrency; // Source fiat currency
@@ -419,6 +422,7 @@ export interface CreateOfframpRequest {
   quote_id: string;
   customer_id: string;
   bank_account_id: string; // The bank IBAN for receiving fiat
+  bank_id?: string; // Iron Finance registered bank account ID — preferred over IBAN when available
   blockchain?: BlockchainType; // The blockchain to use
   source_currency?: CryptoCurrency; // Source crypto currency
   destination_currency?: FiatCurrency; // Destination fiat currency
@@ -797,14 +801,20 @@ class IronFinanceClient {
   async getOnrampQuote(request: OnrampQuoteRequest): Promise<Quote> {
     const params = new URLSearchParams({
       customer_id: request.customer_id,
-      source_currency_code: request.source_currency, // e.g., "EUR"
-      destination_currency_code: request.destination_currency, // e.g., "USDC"
-      destination_currency_chain: request.blockchain || "Base", // Use requested blockchain or default to Base
-      recipient_account: request.wallet_address, // blockchain address (e.g., 0x...)
+      source_currency_code: request.source_currency,
+      destination_currency_code: request.destination_currency,
+      destination_currency_chain: request.blockchain || "Base",
       rate_expiry_policy: "Return",
       expiry_in_hours: "24",
       is_third_party: "false",
     });
+    // Prefer recipient_account_id (registered wallet UUID) over raw address —
+    // Iron Finance requires the ID for some destination currencies (e.g. USDC on Solana).
+    if (request.wallet_id) {
+      params.set("recipient_account_id", request.wallet_id);
+    } else {
+      params.set("recipient_account", request.wallet_address);
+    }
 
     if (request.source_amount) {
       // Convert from cents to decimal string
@@ -837,14 +847,20 @@ class IronFinanceClient {
   async getOfframpQuote(request: OfframpQuoteRequest): Promise<Quote> {
     const params = new URLSearchParams({
       customer_id: request.customer_id,
-      source_currency_code: request.source_currency, // e.g., "USDC"
-      source_currency_chain: request.blockchain || "Base", // Use requested blockchain or default to Base
-      destination_currency_code: request.destination_currency, // e.g., "EUR"
-      recipient_account: request.bank_account_id, // The bank account IBAN
+      source_currency_code: request.source_currency,
+      source_currency_chain: request.blockchain || "Base",
+      destination_currency_code: request.destination_currency,
       rate_expiry_policy: "Return",
       expiry_in_hours: "24",
       is_third_party: "false",
     });
+    // Prefer recipient_account_id (registered bank UUID) over raw IBAN —
+    // Iron Finance requires the ID for some destination currencies.
+    if (request.bank_id) {
+      params.set("recipient_account_id", request.bank_id);
+    } else {
+      params.set("recipient_account", request.bank_account_id);
+    }
 
     if (request.source_amount) {
       // Convert from smallest unit to decimal string
@@ -1025,7 +1041,7 @@ class IronFinanceClient {
         type: "Fiat",
         account_identifier: {
           type: "SEPA",
-          iban: request.bank_account_id, // The bank IBAN
+          iban: request.bank_account_id,
         },
       },
       source_currencies: [


### PR DESCRIPTION
## Summary

- **Multi-wallet registration**: The onboarding wallet step now shows all connected wallets (EVM + Solana) with individual Link buttons, pre-marks already-registered wallets as ✓, and requires at least one linked wallet before continuing. The main page status card also lists all registered wallets and offers a "+ Link another wallet" inline flow.
- **Primary wallet switching**: Uses `useSwitchWallet` before signing so the Dynamic prompt always appears on the correct wallet (EVM or Solana).
- **Chain selector**: Filtered to the user's registered wallet ecosystems — all EVM chains appear if any EVM wallet is registered; Solana only appears if a Solana wallet is registered.
- **Iron Finance API**: GET quote endpoints now send `recipient_account_id` (registered UUID) when available, as required for some currencies. POST create endpoints continue to use the `recipient_account` object form.
- **Resilience**: `handleAddBankAccount` recovers from 409 "already exists" by looking up and advancing instead of getting stuck. `syncToDynamic` retries up to 3× on transient network failures.

## Test plan

- [ ] Connect an EVM wallet → onboarding wallet step shows it with EVM badge, Link button signs + registers, Continue advances to bank
- [ ] Connect a Solana wallet → same flow with SOL badge; address is not lowercased
- [ ] Connect both → both appear, each can be linked independently; Continue unlocks after first link
- [ ] Reload after partial linking → already-linked wallets show as ✓ (fetched from Iron Finance)
- [ ] Quick Ramp with EVM wallet registered → all EVM chains appear, Solana absent
- [ ] Quick Ramp with Solana wallet registered → Solana appears, EVM absent
- [ ] Quick Ramp with both registered → all chains appear
- [ ] Onramp + offramp quote + execute on both EVM and Solana chains — no 400 parse errors
- [ ] Bank step 409 → advances to complete without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)