### PR TITLE
feat(nodejs-langgraph-agent): LangGraph ReAct agent with Dynamic server-side MPC wallet

### DIFF
--- a/examples/nodejs-langgraph-agent/.example.env
+++ b/examples/nodejs-langgraph-agent/.example.env
@@ -1,19 +1,6 @@
 # ─── Anthropic (the LLM driving the agent) ──────────────────────────────────
 ANTHROPIC_API_KEY=sk-ant-your-key-here
 
-# ─── Dynamic environment (delegated signing + balances API) ─────────────────
+# ─── Dynamic environment (server-side MPC signing) ──────────────────────────
 DYNAMIC_ENVIRONMENT_ID=your_environment_id
 DYNAMIC_API_KEY=your_dynamic_api_key
-
-# A user JWT is required for the get_token_balances tool (Dynamic balances API).
-DYNAMIC_USER_JWT=your_user_jwt
-
-# ─── Delegated wallet credentials ───────────────────────────────────────────
-# These come from the user approving delegation in the Dynamic SDK (client-side),
-# delivered to your server via Dynamic's webhook. For local dev you can paste the
-# pre-decrypted values here. NEVER commit real values — this file is an example only.
-DELEGATED_WALLET_ID=your_wallet_id
-DELEGATED_WALLET_ADDRESS=0xyour_wallet_address
-DELEGATED_WALLET_API_KEY=your_wallet_api_key
-# JSON string of the server key share, e.g. {"type":"..."}
-DELEGATED_KEY_SHARE={}

--- a/examples/nodejs-langgraph-agent/.example.env
+++ b/examples/nodejs-langgraph-agent/.example.env
@@ -1,0 +1,19 @@
+# ─── Anthropic (the LLM driving the agent) ──────────────────────────────────
+ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# ─── Dynamic environment (delegated signing + balances API) ─────────────────
+DYNAMIC_ENVIRONMENT_ID=your_environment_id
+DYNAMIC_API_KEY=your_dynamic_api_key
+
+# A user JWT is required for the get_token_balances tool (Dynamic balances API).
+DYNAMIC_USER_JWT=your_user_jwt
+
+# ─── Delegated wallet credentials ───────────────────────────────────────────
+# These come from the user approving delegation in the Dynamic SDK (client-side),
+# delivered to your server via Dynamic's webhook. For local dev you can paste the
+# pre-decrypted values here. NEVER commit real values — this file is an example only.
+DELEGATED_WALLET_ID=your_wallet_id
+DELEGATED_WALLET_ADDRESS=0xyour_wallet_address
+DELEGATED_WALLET_API_KEY=your_wallet_api_key
+# JSON string of the server key share, e.g. {"type":"..."}
+DELEGATED_KEY_SHARE={}

--- a/examples/nodejs-langgraph-agent/.gitignore
+++ b/examples/nodejs-langgraph-agent/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.env
+.env.*
+!.example.env
+*.log
+.DS_Store

--- a/examples/nodejs-langgraph-agent/.gitignore
+++ b/examples/nodejs-langgraph-agent/.gitignore
@@ -5,3 +5,4 @@ dist/
 !.example.env
 *.log
 .DS_Store
+.wallet-state.json

--- a/examples/nodejs-langgraph-agent/README.md
+++ b/examples/nodejs-langgraph-agent/README.md
@@ -1,17 +1,17 @@
-# Bare-bones LangGraph agent + Dynamic delegated wallet
+# Bare-bones LangGraph agent + Dynamic server wallet
 
-A minimal [LangGraph](https://github.com/langchain-ai/langgraphjs) ReAct agent that
-acts on a user's wallet through a **Dynamic delegated MPC wallet**. The user grants
-the agent signing access in the Dynamic SDK; the agent signs and broadcasts
-transactions server-side via Dynamic's MPC — no private keys are ever held by the agent.
+A minimal [LangGraph](https://github.com/langchain-ai/langgraphjs) ReAct agent
+that acts through its own **Dynamic server-side MPC wallet**. The agent creates
+and owns its wallet entirely server-side — no user JWT, no delegation, no
+client-side approval flow required.
 
 It ships three tools:
 
 | Tool | What it does |
 | --- | --- |
-| `list_wallets` | Returns the delegated wallet address. |
-| `get_token_balances` | Multi-chain balances via Dynamic's balances API (optional USD prices). |
-| `send_transaction` | Native transfer, signed via Dynamic MPC. **Always** gated behind a `y/N` confirm prompt. |
+| `list_wallets` | Returns the agent's server wallet address. |
+| `get_token_balances` | Native-token balances across EVM chains via on-chain RPC. |
+| `send_transaction` | Native transfer, signed via Dynamic server-side MPC. **Always** gated behind a `y/N` confirm prompt. |
 
 ## How it works
 
@@ -19,8 +19,9 @@ It ships three tools:
 You ──▶ LangGraph ReAct agent (Claude) ──▶ tools ──▶ Dynamic MPC signing ──▶ chain
 ```
 
-- **`src/wallet.ts`** — loads delegation credentials from env, creates the Dynamic
-  delegated EVM client, and signs + broadcasts transactions.
+- **`src/wallet.ts`** — initializes the `DynamicEvmWalletClient`, creates a new
+  wallet on first run (persisted to `.wallet-state.json`), and signs + broadcasts
+  transactions.
 - **`src/tools.ts`** — the three LangChain tools above.
 - **`src/agent.ts`** — the `createReactAgent` loop (Claude Haiku 4.5) + system prompt.
 - **`src/index.ts`** — an interactive terminal REPL.
@@ -43,16 +44,7 @@ You ──▶ LangGraph ReAct agent (Claude) ──▶ tools ──▶ Dynamic M
    | Variable | Purpose |
    | --- | --- |
    | `ANTHROPIC_API_KEY` | Drives the agent. |
-   | `DYNAMIC_ENVIRONMENT_ID`, `DYNAMIC_API_KEY` | Dynamic env for delegated signing. |
-   | `DYNAMIC_USER_JWT` | Required by `get_token_balances` (Dynamic balances API). |
-   | `DELEGATED_WALLET_ID`, `DELEGATED_WALLET_ADDRESS`, `DELEGATED_WALLET_API_KEY`, `DELEGATED_KEY_SHARE` | Pre-decrypted delegation credentials. |
-
-   The delegation credentials come from the user approving delegation in the Dynamic
-   SDK (client-side), delivered to your server via Dynamic's webhook. For local dev you
-   can paste the pre-decrypted values into `.env`.
-
-   > **Never commit `.env` or real credentials.** `.env*` is gitignored; only
-   > `.example.env` (placeholders) is tracked.
+   | `DYNAMIC_ENVIRONMENT_ID`, `DYNAMIC_API_KEY` | Dynamic env for server-side MPC signing. |
 
 3. Run it:
 
@@ -60,9 +52,12 @@ You ──▶ LangGraph ReAct agent (Claude) ──▶ tools ──▶ Dynamic M
    pnpm start        # or: pnpm dev  (watch mode)
    ```
 
+   On first run the agent creates an MPC wallet and saves it to `.wallet-state.json`.
+   Subsequent runs reuse the same wallet.
+
    ```
    You: show my wallet
-   Agent: Your delegated wallet is 0x1234…abcd.
+   Agent: Your server wallet is 0x1234…abcd.
 
    You: send 0.001 ETH on ethereum to 0xabc…
    ┌─ ACTION REQUIRED ────────────────────────────────────────
@@ -78,9 +73,8 @@ You ──▶ LangGraph ReAct agent (Claude) ──▶ tools ──▶ Dynamic M
 
 - **Mainnet only.** Supported chains: Ethereum (1), Polygon (137), Base (8453),
   Arbitrum (42161), Optimism (10), BSC (56). Extend `CHAIN_MAP` in `src/wallet.ts`.
+- `.wallet-state.json` contains the server key share — treat it like a private key.
+  It is gitignored; never commit it or expose it to untrusted parties.
 - `send_transaction` only does native transfers. To add ERC-20 transfers or contract
-  calls, build the calldata and extend `sendTransactionDelegated`.
+  calls, build the calldata and extend `sendTransactionServer`.
 - Conversation memory is in-process (`MemorySaver`) and resets on restart.
-
-This is a trimmed-down version of the full `langgraph-dynamic-agent` (which adds
-Polymarket betting, LI.FI cross-chain swaps, and voice).

--- a/examples/nodejs-langgraph-agent/README.md
+++ b/examples/nodejs-langgraph-agent/README.md
@@ -1,0 +1,86 @@
+# Bare-bones LangGraph agent + Dynamic delegated wallet
+
+A minimal [LangGraph](https://github.com/langchain-ai/langgraphjs) ReAct agent that
+acts on a user's wallet through a **Dynamic delegated MPC wallet**. The user grants
+the agent signing access in the Dynamic SDK; the agent signs and broadcasts
+transactions server-side via Dynamic's MPC — no private keys are ever held by the agent.
+
+It ships three tools:
+
+| Tool | What it does |
+| --- | --- |
+| `list_wallets` | Returns the delegated wallet address. |
+| `get_token_balances` | Multi-chain balances via Dynamic's balances API (optional USD prices). |
+| `send_transaction` | Native transfer, signed via Dynamic MPC. **Always** gated behind a `y/N` confirm prompt. |
+
+## How it works
+
+```
+You ──▶ LangGraph ReAct agent (Claude) ──▶ tools ──▶ Dynamic MPC signing ──▶ chain
+```
+
+- **`src/wallet.ts`** — loads delegation credentials from env, creates the Dynamic
+  delegated EVM client, and signs + broadcasts transactions.
+- **`src/tools.ts`** — the three LangChain tools above.
+- **`src/agent.ts`** — the `createReactAgent` loop (Claude Haiku 4.5) + system prompt.
+- **`src/index.ts`** — an interactive terminal REPL.
+- **`src/confirm.ts`** — the confirmation prompt for sensitive actions.
+
+## Setup
+
+1. Install dependencies (this repo uses pnpm):
+
+   ```bash
+   pnpm install
+   ```
+
+2. Create your env file from the example and fill it in:
+
+   ```bash
+   cp .example.env .env
+   ```
+
+   | Variable | Purpose |
+   | --- | --- |
+   | `ANTHROPIC_API_KEY` | Drives the agent. |
+   | `DYNAMIC_ENVIRONMENT_ID`, `DYNAMIC_API_KEY` | Dynamic env for delegated signing. |
+   | `DYNAMIC_USER_JWT` | Required by `get_token_balances` (Dynamic balances API). |
+   | `DELEGATED_WALLET_ID`, `DELEGATED_WALLET_ADDRESS`, `DELEGATED_WALLET_API_KEY`, `DELEGATED_KEY_SHARE` | Pre-decrypted delegation credentials. |
+
+   The delegation credentials come from the user approving delegation in the Dynamic
+   SDK (client-side), delivered to your server via Dynamic's webhook. For local dev you
+   can paste the pre-decrypted values into `.env`.
+
+   > **Never commit `.env` or real credentials.** `.env*` is gitignored; only
+   > `.example.env` (placeholders) is tracked.
+
+3. Run it:
+
+   ```bash
+   pnpm start        # or: pnpm dev  (watch mode)
+   ```
+
+   ```
+   You: show my wallet
+   Agent: Your delegated wallet is 0x1234…abcd.
+
+   You: send 0.001 ETH on ethereum to 0xabc…
+   ┌─ ACTION REQUIRED ────────────────────────────────────────
+   │  Send native transfer
+   │    Chain:  Ethereum (1)
+   │    To:     0xabc…
+   │    Amount: 0.001 ETH
+   └──────────────────────────────────────────────────────────
+   Proceed? [y/N]
+   ```
+
+## Notes
+
+- **Mainnet only.** Supported chains: Ethereum (1), Polygon (137), Base (8453),
+  Arbitrum (42161), Optimism (10), BSC (56). Extend `CHAIN_MAP` in `src/wallet.ts`.
+- `send_transaction` only does native transfers. To add ERC-20 transfers or contract
+  calls, build the calldata and extend `sendTransactionDelegated`.
+- Conversation memory is in-process (`MemorySaver`) and resets on restart.
+
+This is a trimmed-down version of the full `langgraph-dynamic-agent` (which adds
+Polymarket betting, LI.FI cross-chain swaps, and voice).

--- a/examples/nodejs-langgraph-agent/package.json
+++ b/examples/nodejs-langgraph-agent/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "nodejs-langgraph-agent",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Bare-bones LangGraph ReAct agent backed by a Dynamic delegated MPC wallet",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "dev": "tsx watch src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@dynamic-labs-wallet/node": "1.0.25",
+    "@dynamic-labs-wallet/node-evm": "1.0.25",
+    "@langchain/anthropic": "1.4.0",
+    "@langchain/core": "1.1.47",
+    "@langchain/langgraph": "1.3.2",
+    "dotenv": "17.4.2",
+    "viem": "2.50.4",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "25.9.1",
+    "tsx": "4.22.3",
+    "typescript": "6.0.3"
+  }
+}

--- a/examples/nodejs-langgraph-agent/package.json
+++ b/examples/nodejs-langgraph-agent/package.json
@@ -2,7 +2,7 @@
   "name": "nodejs-langgraph-agent",
   "version": "1.0.0",
   "private": true,
-  "description": "Bare-bones LangGraph ReAct agent backed by a Dynamic delegated MPC wallet",
+  "description": "Bare-bones LangGraph ReAct agent backed by a Dynamic server-side MPC wallet",
   "type": "module",
   "scripts": {
     "start": "tsx src/index.ts",
@@ -16,6 +16,7 @@
     "@langchain/core": "1.1.47",
     "@langchain/langgraph": "1.3.2",
     "dotenv": "17.4.2",
+    "langchain": "1.4.1",
     "viem": "2.50.4",
     "zod": "4.4.3"
   },

--- a/examples/nodejs-langgraph-agent/pnpm-lock.yaml
+++ b/examples/nodejs-langgraph-agent/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
+      langchain:
+        specifier: 1.4.1
+        version: 1.4.1(@langchain/core@1.1.47(ws@8.20.1))(ws@8.20.1)
       viem:
         specifier: 2.50.4
         version: 2.50.4(typescript@6.0.3)(zod@4.4.3)
@@ -590,7 +593,7 @@ packages:
       viem: ^2.28.0
 
   '@zerodev/webauthn-key@5.5.0':
-    resolution: {integrity: sha512-AbD2d/qrsX7AWxJMEfwxnLbp1TjiUjc1V4ne3Q40UJxKe+lW64Td+y8OD0qSFMqgN6rQxJZ0aOAXmat8H6xluA==}
+    resolution: {integrity: sha512-AbD2d/qrsX7AWxJMEfwxnLbp1TjiUjc1V4ne3Q40UJxKe+lW64Td+y8OD0qSFMqgN6rQxJZ0aOAXmat8H6xluA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@zerodev/webauthn-key/-/webauthn-key-5.5.0.tgz}
     peerDependencies:
       viem: ^2.28.0
 
@@ -797,7 +800,7 @@ packages:
     resolution: {integrity: sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==}
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -874,6 +877,12 @@ packages:
 
   keyvaluestorage-interface@1.0.0:
     resolution: {integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==}
+
+  langchain@1.4.1:
+    resolution: {integrity: sha512-LHGdj0OQV5pgyZgC2WWiEvNg5g16dg+c3j7pw7Iuw7tJXEvltNLVl6DjC6egxSsWT03FJN0eUJxJ13Dxhz2bBA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.1.47
 
   langsmith@0.7.1:
     resolution: {integrity: sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==}
@@ -2558,6 +2567,25 @@ snapshots:
       ts-algebra: 2.0.0
 
   keyvaluestorage-interface@1.0.0: {}
+
+  langchain@1.4.1(@langchain/core@1.1.47(ws@8.20.1))(ws@8.20.1):
+    dependencies:
+      '@langchain/core': 1.1.47(ws@8.20.1)
+      '@langchain/langgraph': 1.3.2(@langchain/core@1.1.47(ws@8.20.1))(zod@4.4.3)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.47(ws@8.20.1))
+      langsmith: 0.7.1(ws@8.20.1)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
 
   langsmith@0.7.1(ws@8.20.1):
     dependencies:

--- a/examples/nodejs-langgraph-agent/pnpm-lock.yaml
+++ b/examples/nodejs-langgraph-agent/pnpm-lock.yaml
@@ -1,0 +1,2902 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@dynamic-labs-wallet/node':
+        specifier: 1.0.25
+        version: 1.0.25
+      '@dynamic-labs-wallet/node-evm':
+        specifier: 1.0.25
+        version: 1.0.25(@dynamic-labs-wallet/forward-mpc-client@0.10.1(@dynamic-labs-wallet/primitives@1.0.25))(@zerodev/webauthn-key@5.5.0(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)))(typescript@6.0.3)(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))(zod@4.4.3)
+      '@langchain/anthropic':
+        specifier: 1.4.0
+        version: 1.4.0(@langchain/core@1.1.47(ws@8.20.1))
+      '@langchain/core':
+        specifier: 1.1.47
+        version: 1.1.47(ws@8.20.1)
+      '@langchain/langgraph':
+        specifier: 1.3.2
+        version: 1.3.2(@langchain/core@1.1.47(ws@8.20.1))(zod@4.4.3)
+      dotenv:
+        specifier: 17.4.2
+        version: 17.4.2
+      viem:
+        specifier: 2.50.4
+        version: 2.50.4(typescript@6.0.3)(zod@4.4.3)
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 25.9.1
+        version: 25.9.1
+      tsx:
+        specifier: 4.22.3
+        version: 4.22.3
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@anthropic-ai/sdk@0.95.2':
+    resolution: {integrity: sha512-Egddwo3sheo1PzUrMkZnH6VkQYwS0h/b/i8vSK8Ta9M45UQipAMeDFH57dYuDAfXMEUUGeKw6CMlremgMZgrSQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
+  '@dynamic-labs-sdk/assert-package-version@0.3.0':
+    resolution: {integrity: sha512-RzBE/6OvFyZrsPK3mOysD2kVygeVwOSZT8vOmprBWculf/HL0urFWU2xtti/VBbnM7UceppOR7JpzgYrgU14FA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@dynamic-labs-sdk/assert-package-version/-/assert-package-version-0.3.0.tgz}
+
+  '@dynamic-labs-sdk/client@0.3.0':
+    resolution: {integrity: sha512-niOsqe4GG3AChghIFvNmdyAa5OtWC+YLFMUw39fP7UOkp3qGclr/oKDSBxcRxs3CyEP+HZdfAvizx2AYqs5PTg==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@dynamic-labs-sdk/client/-/client-0.3.0.tgz}
+
+  '@dynamic-labs-sdk/evm@0.3.0':
+    resolution: {integrity: sha512-dn7PKxgYjKqmkkIRLhNUJGHrtR9DgF/QPtkWZ3EqEd8OMc7y6wTLerRJstWRLjmK6BY0QqdaRbgG5DB0Wb4o3Q==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs-sdk/evm/-/@dynamic-labs-sdk/evm-0.3.0.tgz}
+    peerDependencies:
+      viem: ^2.28.4
+
+  '@dynamic-labs-sdk/wallet-connect@0.3.0':
+    resolution: {integrity: sha512-QDFrZ/5LbDw3Z84sVtRUdjqROTvvhCPJsnthWjGzsdZoO0jrIetRVZcfD7pUwRX39Fq5fXpC4maL6yTilej5PQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@dynamic-labs-sdk/wallet-connect/-/wallet-connect-0.3.0.tgz}
+
+  '@dynamic-labs-sdk/zerodev@0.3.0':
+    resolution: {integrity: sha512-2zWvwpf+I7ncDTvMvfbOMbsNcqMYJGQWkX5VEsfuU9setCxLfahlGr7conWds8WxhllRbnMer8DLM8aXiNP/vg==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@dynamic-labs-sdk/zerodev/-/zerodev-0.3.0.tgz}
+    peerDependencies:
+      viem: ^2.28.4
+
+  '@dynamic-labs-wallet/browser-wallet-client@0.0.250':
+    resolution: {integrity: sha512-TJroeuP7KrLTgBN1Kc1ptD1hdGqawGBrNnyijZPJbAEocbMZIZhba7Yp/P8zg2h5CuPOvMcj1LPiAh3UPfJULQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@dynamic-labs-wallet/browser-wallet-client/-/browser-wallet-client-0.0.250.tgz}
+
+  '@dynamic-labs-wallet/browser@0.0.167':
+    resolution: {integrity: sha512-HDmUetnJ1iz6kGd5PB1kJzeLI7ZJmwxlJ1QGtUqSQHDdBkhLwaDPlccB2IviC5iPfU5PR/IQ1BYEqpoTWx2sBA==}
+
+  '@dynamic-labs-wallet/browser@0.0.203':
+    resolution: {integrity: sha512-Vwi4CFMjSiLsPF4VUlYV4F87xaQrgnmUVUVx3b5F0I5DbFsGLafiSl2T/dlsOeNuRAhbpDMU4MEB4oOxzR0kYQ==}
+
+  '@dynamic-labs-wallet/core@0.0.167':
+    resolution: {integrity: sha512-jEHD/mDfnqx2/ML/MezY725uPPrKGsGoR3BaS1JNITGIitai1gPEgaEMqbXIhzId/m+Xieb8ZrLDiaYYJcXcyQ==}
+
+  '@dynamic-labs-wallet/core@0.0.203':
+    resolution: {integrity: sha512-1ykOANTDCPPaIpajpKqRxfISGYrmiMs7WMZQzdzRkTLftpnatgycYjdZrX9adhE1kY9BMrPdhfYaaE5B9wbFbQ==}
+
+  '@dynamic-labs-wallet/core@0.0.250':
+    resolution: {integrity: sha512-0gKs/DI82kdM/V0EViCM1pJ/LzVjNjpFiC6HX3nO+HfJLlanaBuRPIAZPjfTErJm3Ohj4rr4G7H39qsI7gb9QQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs-wallet/core/-/@dynamic-labs-wallet/core-0.0.250.tgz}
+
+  '@dynamic-labs-wallet/core@1.0.25':
+    resolution: {integrity: sha512-xLZKiSPkprJgQu++L2WFwo0BBtOMEcs45kUvICZbOgZpFaIISVRDSAtaUMADrvXn4+GIQ7tGiCLNLWUjpAP41g==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs-wallet/core/-/@dynamic-labs-wallet/core-1.0.25.tgz}
+    peerDependencies:
+      '@dynamic-labs-wallet/forward-mpc-client': 0.10.1
+
+  '@dynamic-labs-wallet/forward-mpc-client@0.1.3':
+    resolution: {integrity: sha512-riZesfU41fMvetaxJ3bO48/9P8ikRPgoVJgWh8m8i0oRyYN7uUz+Iesp+52U12DCtcvSTXljxrKtrV3yqNAYRw==}
+
+  '@dynamic-labs-wallet/forward-mpc-client@0.10.1':
+    resolution: {integrity: sha512-gFl+eAPH8k3LwJrSA/IWi5L78nSgZAdOBPodLaxF6ZMXyJC8Lv2emrVG/zvEVWjuPWqTMpkhG7TM65vB6D31CQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs-wallet/forward-mpc-client/-/@dynamic-labs-wallet/forward-mpc-client-0.10.1.tgz}
+    peerDependencies:
+      '@dynamic-labs-wallet/primitives': '>=0.0.336 || 0.0.1'
+
+  '@dynamic-labs-wallet/forward-mpc-client@0.2.0':
+    resolution: {integrity: sha512-zkn5eYPPkjOFRi8POHXM+rl2lW+0AKjqiKPdNYmJieegI8PuXqq9Q0UzVWISwzpqmMX4/nQmK+9cqbPDW9Lu6A==}
+
+  '@dynamic-labs-wallet/forward-mpc-shared@0.1.0':
+    resolution: {integrity: sha512-xRpMri4+ZuClonwf04RcnT/BCG8oA36ononD7s0MA5wSqd8kOuHjzNTSoM6lWnPiCmlpECyPARJ1CEO02Sfq9Q==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@dynamic-labs-wallet/forward-mpc-shared/-/forward-mpc-shared-0.1.0.tgz}
+
+  '@dynamic-labs-wallet/forward-mpc-shared@0.2.0':
+    resolution: {integrity: sha512-2I8NoCBVT9/09o4+M78S2wyY9jVXAb6RKt5Bnh1fhvikuB11NBeswtfZLns3wAFQxayApe31Jhamd4D2GR+mtw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@dynamic-labs-wallet/forward-mpc-shared/-/forward-mpc-shared-0.2.0.tgz}
+
+  '@dynamic-labs-wallet/forward-mpc-shared@0.7.0':
+    resolution: {integrity: sha512-mN6zT5J8JbZxkOJxEjgGrjURybVn/t9DD+pWW5U4DRZH6Qakn5n1LIB4Lg4Y7OW9WwrlMH2IJ9RNgBW35RaF1A==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@dynamic-labs-wallet/forward-mpc-shared/-/forward-mpc-shared-0.7.0.tgz}
+    peerDependencies:
+      '@dynamic-labs-wallet/primitives': '>=0.0.336 || 0.0.1'
+
+  '@dynamic-labs-wallet/node-evm@1.0.25':
+    resolution: {integrity: sha512-wJnsSdSGBfOBUAHv7R69xbwBjNSDj5kd7KoBn6ptqc3iUn1t1TpFJCm8j09jGtXK7L/DK/E+gkSS0GoiGv8gtg==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs-wallet/node-evm/-/@dynamic-labs-wallet/node-evm-1.0.25.tgz}
+    peerDependencies:
+      viem: ^2.45.3
+
+  '@dynamic-labs-wallet/node@1.0.25':
+    resolution: {integrity: sha512-hcbdBOfWQdgAVJ9z1OHSzBDjPunw1+XXHEWT5dQykREMcoBQPwvp2uzuxMhbr/t9lez7WD55bliN/zp4dDt9ew==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs-wallet/node/-/@dynamic-labs-wallet/node-1.0.25.tgz}
+
+  '@dynamic-labs-wallet/primitives@1.0.25':
+    resolution: {integrity: sha512-1F3ss8dFSzUU1zgsuCrGVVyc+k4XbVyDfYvHWRoAdbveXAVDcFiHkmqRZFI1wvSLi+zF2huEtk3D5BvvrcDTNw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs-wallet/primitives/-/@dynamic-labs-wallet/primitives-1.0.25.tgz}
+
+  '@dynamic-labs/assert-package-version@4.88.3':
+    resolution: {integrity: sha512-BHcjQMxwTsxt5Q20XHBd6j6HZLs8ug5784g8o4kl2RcDZ40dLLW7qwrVibulnPumQSbFBCohnkgFASP2xcgDaA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs/assert-package-version/-/@dynamic-labs/assert-package-version-4.88.3.tgz}
+
+  '@dynamic-labs/logger@4.88.3':
+    resolution: {integrity: sha512-KfxSd1oDfGXQCgX2KgQb/vR90nLG8A2pU7zK7UeX9hDYD0DbvV8rxcgjFR+ZIOj8E6f7J2SdXYLazl0ABjOMhA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs/logger/-/@dynamic-labs/logger-4.88.3.tgz}
+
+  '@dynamic-labs/message-transport@4.88.3':
+    resolution: {integrity: sha512-te9ZBbXFj4w5GQIqf6TAYqFXubBUevJKZN7JbSGBqpQkzhzTQMdBrQk9K6CUXtclmiqak6cdrYP3Oqy6NLGBmQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs/message-transport/-/@dynamic-labs/message-transport-4.88.3.tgz}
+
+  '@dynamic-labs/sdk-api-core@0.0.1015':
+    resolution: {integrity: sha512-IERnw3pYJfpWQLgMJOwaD/cMs+bq2L2k0JaFR21tjtfkQww+v98VNyTrW8ptTHluEguJQftxTKT+IrQb5vyvFw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs/sdk-api-core/-/@dynamic-labs/sdk-api-core-0.0.1015.tgz}
+
+  '@dynamic-labs/sdk-api-core@0.0.764':
+    resolution: {integrity: sha512-79JptJTTClLc9qhioThtwMuzTHJ+mrj8sTEglb7Mcx3lJub9YbXqNdzS9mLRxZsr2et3aqqpzymXdUBzSEaMng==}
+
+  '@dynamic-labs/sdk-api-core@0.0.818':
+    resolution: {integrity: sha512-s0iq+kS15gbBk7HtFEVkuzHHUc8Xt0afA1el31+c8HBLIV0Bz1O4WaMTKdpvC/Rb5RS5GDCOmxeR6LvDzZBw+A==}
+
+  '@dynamic-labs/sdk-api-core@0.0.828':
+    resolution: {integrity: sha512-tLUbH3Koo6OgtWGoklao4KHuerUIKKazRSAMet9xde933HaA+0qXWopld4uvVJCB6hVb4GHo5CdbpSRXSBgGCw==}
+
+  '@dynamic-labs/sdk-api-core@0.0.860':
+    resolution: {integrity: sha512-zJQU5AvyvBWwhUq0K2tOKCTR5rSt8PWYaem+edGRV+InyWT0OuKn6jUJttpFgSqOg3XHlCqUFwLmff76OmhCfw==}
+
+  '@dynamic-labs/sdk-api-core@0.0.984':
+    resolution: {integrity: sha512-smSL1nUDZ753Ldeb848GJufOzEMzkGUcDdxUVcfmfHnA8kEdmKO+c/4nfQEUeDNvaFxd9ueB9ZKTYkLC2t/uXg==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs/sdk-api-core/-/@dynamic-labs/sdk-api-core-0.0.984.tgz}
+
+  '@dynamic-labs/types@4.88.3':
+    resolution: {integrity: sha512-lywjKHU+ENOvSxJsIoIcTX38DYxvPji79cet1nA8ZaowlaQwDIRdpbbBKxyFt1wm1oVlVxnipUK1rULxfDLKsA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs/types/-/@dynamic-labs/types-4.88.3.tgz}
+
+  '@dynamic-labs/utils@4.88.3':
+    resolution: {integrity: sha512-peaRPoAUOee6RxpMpWx8hhhQTPETqd4UxOQ1xbWqT7+wZmJhJSPT8UtWv+O2qmSY27TcP9cYoaW73SNnrdQujg==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/dynamic-npm/@dynamic-labs/utils/-/@dynamic-labs/utils-4.88.3.tgz}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/android-arm/-/android-arm-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/android-x64/-/android-x64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ethereumjs/rlp@4.0.1':
+    resolution: {integrity: sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  '@ethereumjs/util@8.1.0':
+    resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
+    engines: {node: '>=14'}
+
+  '@evervault/wasm-attestation-bindings@0.3.1':
+    resolution: {integrity: sha512-pJsbax/pEPdRXSnFKahzGZeq2CNTZ0skAPWpnEZK/8vdcvlan7LE7wMSOVr+Z+MqTBnVEnS7O80TKpXKU5Rsbw==}
+
+  '@langchain/anthropic@1.4.0':
+    resolution: {integrity: sha512-rs1yVydrHjyiD31uChdCnKZpmDuKa0Bpz8Raiy9GvqnqmfXPMe0oOrap/2paE+NRSinDbtax8mMpP/yv8EbO1A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.1.47
+
+  '@langchain/core@1.1.47':
+    resolution: {integrity: sha512-+fiPu6ZFnJMrZyKeM77OIVPoMPAY6OKWacnPlojHtXTbMMzb2cEOKAJV0U07cDl86NHSCIYYa0i4CyKZzXbHQQ==}
+    engines: {node: '>=20'}
+
+  '@langchain/langgraph-checkpoint@1.0.2':
+    resolution: {integrity: sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.1.44
+
+  '@langchain/langgraph-sdk@1.9.4':
+    resolution: {integrity: sha512-hhASJGKa2MDJDtDkuIFdWGysMTog/HkYe0r6B6Gn1XqsURWnF7FIFl9diITAPOv1tB8YpyjnbpsBj/NkT5d+jQ==}
+    peerDependencies:
+      '@langchain/core': ^1.1.44
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+      svelte: ^4.0.0 || ^5.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
+  '@langchain/langgraph@1.3.2':
+    resolution: {integrity: sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.1.44
+      zod: ^3.25.32 || ^4.2.0
+      zod-to-json-schema: ^3.x
+    peerDependenciesMeta:
+      zod-to-json-schema:
+        optional: true
+
+  '@langchain/protocol@0.0.15':
+    resolution: {integrity: sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==}
+
+  '@msgpack/msgpack@3.1.2':
+    resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@msgpack/msgpack/-/msgpack-3.1.2.tgz}
+    engines: {node: '>= 18'}
+
+  '@noble/ciphers@0.4.1':
+    resolution: {integrity: sha512-QCOA9cgf3Rc33owG0AYBB9wszz+Ul2kramWN8tXG44Gyciud/tbkEqvxRF/IpqQaBpRBNi9f4jdNxqB2CQCIXg==}
+
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.4.2':
+    resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
+
+  '@noble/curves@1.8.0':
+    resolution: {integrity: sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.2':
+    resolution: {integrity: sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@2.0.1':
+    resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@1.4.0':
+    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
+    engines: {node: '>= 16'}
+
+  '@noble/hashes@1.7.0':
+    resolution: {integrity: sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.7.1':
+    resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/post-quantum@0.5.4':
+    resolution: {integrity: sha512-leww0zzIirrvwaYMPI9fj6aRIlA/c6Y0/lifQQ1YOOyHEr0MNH3yYpjXeiVG+tWdPps4XxGclFWX2INPO3Yo5w==}
+    engines: {node: '>= 20.19.0'}
+
+  '@scure/base@1.1.9':
+    resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.4.0':
+    resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.3.0':
+    resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  '@simplewebauthn/browser@13.1.0':
+    resolution: {integrity: sha512-WuHZ/PYvyPJ9nxSzgHtOEjogBhwJfC8xzYkPC+rR/+8chl/ft4ngjiK8kSU5HtRJfczupyOh33b25TjYbvwAcg==}
+
+  '@simplewebauthn/browser@8.3.7':
+    resolution: {integrity: sha512-ZtRf+pUEgOCvjrYsbMsJfiHOdKcrSZt2zrAnIIpfmA06r0FxBovFYq0rJ171soZbe13KmWzAoLKjSxVW7KxCdQ==}
+
+  '@simplewebauthn/browser@9.0.1':
+    resolution: {integrity: sha512-wD2WpbkaEP4170s13/HUxPcAV5y4ZXaKo1TfNklS5zDefPinIgXOpgz1kpEvobAsaLPa2KeH7AKKX/od1mrBJw==}
+
+  '@simplewebauthn/types@12.0.0':
+    resolution: {integrity: sha512-q6y8MkoV8V8jB4zzp18Uyj2I7oFp2/ONL8c3j8uT06AOWu3cIChc1au71QYHrP2b+xDapkGTiv+9lX7xkTlAsA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  '@simplewebauthn/types@9.0.1':
+    resolution: {integrity: sha512-tGSRP1QvsAvsJmnOlRQyw/mvK9gnPtjEc5fg2+m8n+QUa+D7rvrKkOYyfpy42GTs90X3RDOnqJgfHt+qO67/+w==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  '@simplewebauthn/typescript-types@8.3.4':
+    resolution: {integrity: sha512-38xtca0OqfRVNloKBrFB5LEM6PN5vzFbJG6rAutPVrtGHFYxPdiV3btYWq0eAZAZmP+dqFPYJxJWeJrGfmYHng==}
+    deprecated: This package has been renamed to @simplewebauthn/types. Please install @simplewebauthn/types instead to ensure you receive future updates.
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@vue/reactivity@3.5.34':
+    resolution: {integrity: sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==}
+
+  '@vue/shared@3.5.34':
+    resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@vue/shared/-/shared-3.5.34.tgz}
+
+  '@walletconnect/core@2.21.8':
+    resolution: {integrity: sha512-MD1SY7KAeHWvufiBK8C1MwP9/pxxI7SnKi/rHYfjco2Xvke+M+Bbm2OzvuSN7dYZvwLTkZCiJmBccTNVPCpSUQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/core/-/core-2.21.8.tgz}
+    engines: {node: '>=18'}
+
+  '@walletconnect/environment@1.0.1':
+    resolution: {integrity: sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==}
+
+  '@walletconnect/events@1.0.1':
+    resolution: {integrity: sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==}
+
+  '@walletconnect/heartbeat@1.2.2':
+    resolution: {integrity: sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/heartbeat/-/heartbeat-1.2.2.tgz}
+
+  '@walletconnect/jsonrpc-provider@1.0.14':
+    resolution: {integrity: sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz}
+
+  '@walletconnect/jsonrpc-types@1.0.4':
+    resolution: {integrity: sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==}
+
+  '@walletconnect/jsonrpc-utils@1.0.8':
+    resolution: {integrity: sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==}
+
+  '@walletconnect/jsonrpc-ws-connection@1.0.16':
+    resolution: {integrity: sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz}
+
+  '@walletconnect/keyvaluestorage@1.1.1':
+    resolution: {integrity: sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz}
+    peerDependencies:
+      '@react-native-async-storage/async-storage': 1.x
+    peerDependenciesMeta:
+      '@react-native-async-storage/async-storage':
+        optional: true
+
+  '@walletconnect/logger@2.1.2':
+    resolution: {integrity: sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/logger/-/logger-2.1.2.tgz}
+
+  '@walletconnect/relay-api@1.0.11':
+    resolution: {integrity: sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/relay-api/-/relay-api-1.0.11.tgz}
+
+  '@walletconnect/relay-auth@1.1.0':
+    resolution: {integrity: sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/relay-auth/-/relay-auth-1.1.0.tgz}
+
+  '@walletconnect/safe-json@1.0.2':
+    resolution: {integrity: sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==}
+
+  '@walletconnect/sign-client@2.21.8':
+    resolution: {integrity: sha512-lTcUbMjQ0YUZ5wzCLhpBeS9OkWYgLLly6BddEp2+pm4QxiwCCU2Nao0nBJXgzKbZYQOgrEGqtdm/7ze67gjzRA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/sign-client/-/sign-client-2.21.8.tgz}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
+
+  '@walletconnect/time@1.0.2':
+    resolution: {integrity: sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==}
+
+  '@walletconnect/types@2.21.8':
+    resolution: {integrity: sha512-xuLIPrLxe6viMu8Uk28Nf0sgyMy+4oT0mroOjBe5Vqyft8GTiwUBKZXmrGU9uDzZsYVn1FXLO9CkuNHXda3ODA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/types/-/types-2.21.8.tgz}
+
+  '@walletconnect/utils@2.21.8':
+    resolution: {integrity: sha512-HtMraGJ9qXo55l4wGSM1aZvyz0XVv460iWhlRGAyRl9Yz8RQeKyXavDhwBfcTFha/6kwLxPExqQ+MURtKeVVXw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/utils/-/utils-2.21.8.tgz}
+
+  '@walletconnect/window-getters@1.0.1':
+    resolution: {integrity: sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==}
+
+  '@walletconnect/window-metadata@1.0.1':
+    resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz}
+
+  '@zerodev/ecdsa-validator@5.4.9':
+    resolution: {integrity: sha512-9NVE8/sQIKRo42UOoYKkNdmmHJY8VlT4t+2MHD2ipLg21cpbY9fS17TGZh61+Bl3qlqc8pP23I6f89z9im7kuA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@zerodev/ecdsa-validator/-/ecdsa-validator-5.4.9.tgz}
+    peerDependencies:
+      '@zerodev/sdk': ^5.4.13
+      viem: ^2.28.0
+
+  '@zerodev/multi-chain-ecdsa-validator@5.4.5':
+    resolution: {integrity: sha512-cmQcsl5WbjnyQuhAS76BUqsHGtUOfWqdkMlm60s75kmRKzF5PiKzRpWIZyeISVmJV0F4P5u1keo1xYONEFiw1w==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@zerodev/multi-chain-ecdsa-validator/-/multi-chain-ecdsa-validator-5.4.5.tgz}
+    peerDependencies:
+      '@zerodev/sdk': ^5.4.0
+      '@zerodev/webauthn-key': ^5.4.0
+      viem: ^2.28.0
+
+  '@zerodev/sdk@5.4.36':
+    resolution: {integrity: sha512-8ewwlijbzWA16AZ03w7zqvTVXFdaUqGOJmbcAZPIIuz52bsdBsKYiF37RZ05KJ24hfdYsIHjE8pwocfjrtMcng==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/@zerodev/sdk/-/sdk-5.4.36.tgz}
+    peerDependencies:
+      viem: ^2.28.0
+
+  '@zerodev/webauthn-key@5.5.0':
+    resolution: {integrity: sha512-AbD2d/qrsX7AWxJMEfwxnLbp1TjiUjc1V4ne3Q40UJxKe+lW64Td+y8OD0qSFMqgN6rQxJZ0aOAXmat8H6xluA==}
+    peerDependencies:
+      viem: ^2.28.0
+
+  abitype@1.0.8:
+    resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  argon2id@1.0.1:
+    resolution: {integrity: sha512-rsiD3lX+0L0CsiZARp3bf9EGxprtuWAT7PpiJd+Fk53URV0/USOQkBIP1dLTV8t6aui0ECbymQ9W9YCcTd6XgA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/argon2id/-/argon2id-1.0.1.tgz}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  axios@1.13.2:
+    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+
+  axios@1.9.0:
+    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
+
+  base-x@5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  blakejs@1.2.1:
+    resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/blakejs/-/blakejs-1.2.1.tgz}
+
+  bn.js@4.11.6:
+    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
+
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
+
+  bs58@6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
+  buffer-reverse@1.0.1:
+    resolution: {integrity: sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  cookie-es@1.2.3:
+    resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
+
+  crossws@0.3.5:
+    resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
+
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+
+  decode-uri-component@0.2.2:
+    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
+    engines: {node: '>=0.10'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  detect-browser@5.3.0:
+    resolution: {integrity: sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/detect-browser/-/detect-browser-5.3.0.tgz}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-toolkit@1.39.3:
+    resolution: {integrity: sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/es-toolkit/-/es-toolkit-1.39.3.tgz}
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  ethereum-bloom-filters@1.2.0:
+    resolution: {integrity: sha512-28hyiE7HVsWubqhpVLVmZXFd4ITeHi+BUu05o9isf0GUpMtzBUi+8/gFrGaGYzvGAJQmJ3JKj77Mk9G98T84rA==}
+
+  ethereum-cryptography@2.2.1:
+    resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
+
+  ethjs-unit@0.1.6:
+    resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/ethjs-unit/-/ethjs-unit-0.1.6.tgz}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
+  fast-redact@3.5.0:
+    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
+    engines: {node: '>=6'}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  filter-obj@1.1.0:
+    resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
+    engines: {node: '>=0.10.0'}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  fp-ts@2.16.11:
+    resolution: {integrity: sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  h3@1.15.11:
+    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  idb-keyval@6.2.2:
+    resolution: {integrity: sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  io-ts@2.2.22:
+    resolution: {integrity: sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==}
+    peerDependencies:
+      fp-ts: ^2.5.0
+
+  iron-webcrypto@1.2.1:
+    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+
+  is-hex-prefixed@1.0.0:
+    resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
+
+  js-tiktoken@1.0.21:
+    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
+  keyvaluestorage-interface@1.0.0:
+    resolution: {integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==}
+
+  langsmith@0.7.1:
+    resolution: {integrity: sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+      ws: '>=7'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
+      ws:
+        optional: true
+
+  lru-cache@11.5.0:
+    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
+    engines: {node: 20 || >=22}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  merkletreejs@0.3.11:
+    resolution: {integrity: sha512-LJKTl4iVNTndhL+3Uz/tfkjD0klIWsHlUzgtuNnNrsf7bAlXR30m+xYB7lHr5Z/l6e/yAIsr26Dabx6Buo4VGQ==}
+    engines: {node: '>= 7.6.0'}
+
+  micro-ftch@0.3.1:
+    resolution: {integrity: sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  multiformats@9.9.0:
+    resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-mock-http@1.0.4:
+    resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  number-to-bn@1.7.0:
+    resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/number-to-bn/-/number-to-bn-1.7.0.tgz}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+
+  ofetch@1.5.1:
+    resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
+
+  on-exit-leak-free@0.2.0:
+    resolution: {integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  ox@0.14.22:
+    resolution: {integrity: sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@0.7.1:
+    resolution: {integrity: sha512-+k9fY9PRNuAMHRFIUbiK9Nt5seYHHzSQs9Bj+iMETcGtlpS7SmBzcGSVUQO3+nqGLEiNK4598pHNFlVRaZbRsg==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-queue@9.3.0:
+    resolution: {integrity: sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==}
+    engines: {node: '>=20'}
+
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  pino-abstract-transport@0.5.0:
+    resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz}
+
+  pino-std-serializers@4.0.0:
+    resolution: {integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==}
+
+  pino@7.11.0:
+    resolution: {integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/pino/-/pino-7.11.0.tgz}
+    hasBin: true
+
+  process-warning@1.0.0:
+    resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
+  query-string@7.1.3:
+    resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
+    engines: {node: '>=6'}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  radix3@1.1.2:
+    resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
+  real-require@0.1.0:
+    resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
+    engines: {node: '>= 12.13.0'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sonic-boom@2.8.0:
+    resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
+
+  split-on-first@1.1.0:
+    resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
+    engines: {node: '>=6'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
+  strict-uri-encode@2.0.0:
+    resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
+    engines: {node: '>=4'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-hex-prefix@1.0.0:
+    resolution: {integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+
+  thread-stream@0.15.2:
+    resolution: {integrity: sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.0.16:
+    resolution: {integrity: sha512-TkEq38COU640mzOKPk4D1oH3FFVvwEtMaKIfw/+F/umVsy7ONWu8PPQH0c11qJ/Jq/zbcQGprXGsT8GcaDSmJg==, tarball: https://fbinfra555artifactory.jfrog.io/artifactory/api/npm/fireblocks-npm/tldts/-/tldts-6.0.16.tgz}
+    hasBin: true
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  treeify@1.1.0:
+    resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
+    engines: {node: '>=0.6'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uint8arrays@3.1.1:
+    resolution: {integrity: sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  unstorage@1.17.5:
+    resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1 || ^2 || ^3
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
+        optional: true
+
+  utf8@3.0.0:
+    resolution: {integrity: sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@13.0.2:
+    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
+    hasBin: true
+
+  viem@2.31.0:
+    resolution: {integrity: sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@2.50.4:
+    resolution: {integrity: sha512-rf98F4s3Vlb+uJZEKfay3IbBw3CNCbVtx5Y3UIljlO2tSX420g/J0WQSYsjzBSasUFgxgsXabji14O9kGbiqgg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  web3-utils@1.10.4:
+    resolution: {integrity: sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==}
+    engines: {node: '>=8.0.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.2:
+    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  zod@4.0.5:
+    resolution: {integrity: sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@adraffy/ens-normalize@1.11.1': {}
+
+  '@anthropic-ai/sdk@0.95.2(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
+
+  '@babel/runtime@7.29.2': {}
+
+  '@cfworker/json-schema@4.1.1': {}
+
+  '@dynamic-labs-sdk/assert-package-version@0.3.0': {}
+
+  '@dynamic-labs-sdk/client@0.3.0':
+    dependencies:
+      '@dynamic-labs-sdk/assert-package-version': 0.3.0
+      '@dynamic-labs-wallet/browser-wallet-client': 0.0.250
+      '@dynamic-labs/sdk-api-core': 0.0.860
+      '@simplewebauthn/browser': 13.1.0
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      zod: 4.0.5
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@dynamic-labs-sdk/evm@0.3.0(typescript@6.0.3)(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@dynamic-labs-sdk/assert-package-version': 0.3.0
+      '@dynamic-labs-sdk/client': 0.3.0
+      '@dynamic-labs-sdk/wallet-connect': 0.3.0(typescript@6.0.3)
+      '@dynamic-labs/sdk-api-core': 0.0.860
+      '@walletconnect/types': 2.21.8
+      '@walletconnect/utils': 2.21.8(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.50.4(typescript@6.0.3)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@dynamic-labs-sdk/wallet-connect@0.3.0(typescript@6.0.3)':
+    dependencies:
+      '@dynamic-labs-sdk/assert-package-version': 0.3.0
+      '@dynamic-labs-sdk/client': 0.3.0
+      '@dynamic-labs/sdk-api-core': 0.0.860
+      '@walletconnect/sign-client': 2.21.8(typescript@6.0.3)(zod@4.0.5)
+      '@walletconnect/types': 2.21.8
+      '@walletconnect/utils': 2.21.8(typescript@6.0.3)(zod@4.0.5)
+      zod: 4.0.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+
+  '@dynamic-labs-sdk/zerodev@0.3.0(@zerodev/webauthn-key@5.5.0(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)))(typescript@6.0.3)(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@dynamic-labs-sdk/assert-package-version': 0.3.0
+      '@dynamic-labs-sdk/client': 0.3.0
+      '@dynamic-labs-sdk/evm': 0.3.0(typescript@6.0.3)(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))(zod@4.4.3)
+      '@dynamic-labs/sdk-api-core': 0.0.860
+      '@zerodev/ecdsa-validator': 5.4.9(@zerodev/sdk@5.4.36(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)))(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))
+      '@zerodev/multi-chain-ecdsa-validator': 5.4.5(@zerodev/sdk@5.4.36(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)))(@zerodev/webauthn-key@5.5.0(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)))(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))
+      '@zerodev/sdk': 5.4.36(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))
+      viem: 2.50.4(typescript@6.0.3)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@zerodev/webauthn-key'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@dynamic-labs-wallet/browser-wallet-client@0.0.250':
+    dependencies:
+      '@dynamic-labs-wallet/core': 0.0.250
+      '@dynamic-labs/logger': 4.88.3
+      '@dynamic-labs/message-transport': 4.88.3
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@dynamic-labs-wallet/browser@0.0.167':
+    dependencies:
+      '@dynamic-labs-wallet/core': 0.0.167
+      '@dynamic-labs/logger': 4.88.3
+      '@dynamic-labs/sdk-api-core': 0.0.764
+      '@noble/hashes': 1.7.1
+      argon2id: 1.0.1
+      axios: 1.9.0
+      http-errors: 2.0.0
+      semver: 7.8.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+
+  '@dynamic-labs-wallet/browser@0.0.203':
+    dependencies:
+      '@dynamic-labs-wallet/core': 0.0.203
+      '@dynamic-labs/logger': 4.88.3
+      '@dynamic-labs/sdk-api-core': 0.0.818
+      '@noble/hashes': 1.7.1
+      argon2id: 1.0.1
+      axios: 1.13.2
+      http-errors: 2.0.0
+      semver: 7.8.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@dynamic-labs-wallet/core@0.0.167':
+    dependencies:
+      '@dynamic-labs/sdk-api-core': 0.0.764
+      axios: 1.9.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+
+  '@dynamic-labs-wallet/core@0.0.203':
+    dependencies:
+      '@dynamic-labs-wallet/forward-mpc-client': 0.1.3
+      '@dynamic-labs/logger': 4.88.3
+      '@dynamic-labs/sdk-api-core': 0.0.818
+      axios: 1.13.2
+      http-errors: 2.0.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@dynamic-labs-wallet/core@0.0.250':
+    dependencies:
+      '@dynamic-labs-wallet/forward-mpc-client': 0.2.0
+      '@dynamic-labs/logger': 4.88.3
+      '@dynamic-labs/sdk-api-core': 0.0.828
+      axios: 1.13.2
+      http-errors: 2.0.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@dynamic-labs-wallet/core@1.0.25(@dynamic-labs-wallet/forward-mpc-client@0.10.1(@dynamic-labs-wallet/primitives@1.0.25))':
+    dependencies:
+      '@dynamic-labs-wallet/forward-mpc-client': 0.10.1(@dynamic-labs-wallet/primitives@1.0.25)
+      '@dynamic-labs-wallet/primitives': 1.0.25
+      '@dynamic-labs/sdk-api-core': 0.0.984
+      axios: 1.16.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+
+  '@dynamic-labs-wallet/forward-mpc-client@0.1.3':
+    dependencies:
+      '@dynamic-labs-wallet/core': 0.0.167
+      '@dynamic-labs-wallet/forward-mpc-shared': 0.1.0
+      '@evervault/wasm-attestation-bindings': 0.3.1
+      '@noble/hashes': 2.2.0
+      '@noble/post-quantum': 0.5.4
+      eventemitter3: 5.0.4
+      fp-ts: 2.16.11
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@dynamic-labs-wallet/forward-mpc-client@0.10.1(@dynamic-labs-wallet/primitives@1.0.25)':
+    dependencies:
+      '@dynamic-labs-wallet/forward-mpc-shared': 0.7.0(@dynamic-labs-wallet/primitives@1.0.25)
+      '@dynamic-labs-wallet/primitives': 1.0.25
+      '@evervault/wasm-attestation-bindings': 0.3.1
+      '@noble/hashes': 2.2.0
+      eventemitter3: 5.0.4
+      fp-ts: 2.16.11
+      isows: 1.0.7(ws@8.20.1)
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@dynamic-labs-wallet/forward-mpc-client@0.2.0':
+    dependencies:
+      '@dynamic-labs-wallet/core': 0.0.203
+      '@dynamic-labs-wallet/forward-mpc-shared': 0.2.0
+      '@evervault/wasm-attestation-bindings': 0.3.1
+      '@noble/hashes': 2.2.0
+      '@noble/post-quantum': 0.5.4
+      eventemitter3: 5.0.4
+      fp-ts: 2.16.11
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@dynamic-labs-wallet/forward-mpc-shared@0.1.0':
+    dependencies:
+      '@dynamic-labs-wallet/browser': 0.0.167
+      '@dynamic-labs-wallet/core': 0.0.167
+      '@noble/ciphers': 0.4.1
+      '@noble/hashes': 2.2.0
+      '@noble/post-quantum': 0.5.4
+      fp-ts: 2.16.11
+      io-ts: 2.2.22(fp-ts@2.16.11)
+    transitivePeerDependencies:
+      - debug
+
+  '@dynamic-labs-wallet/forward-mpc-shared@0.2.0':
+    dependencies:
+      '@dynamic-labs-wallet/browser': 0.0.203
+      '@dynamic-labs-wallet/core': 0.0.203
+      '@noble/ciphers': 0.4.1
+      '@noble/hashes': 2.2.0
+      '@noble/post-quantum': 0.5.4
+      fp-ts: 2.16.11
+      io-ts: 2.2.22(fp-ts@2.16.11)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@dynamic-labs-wallet/forward-mpc-shared@0.7.0(@dynamic-labs-wallet/primitives@1.0.25)':
+    dependencies:
+      '@dynamic-labs-wallet/primitives': 1.0.25
+      '@noble/ciphers': 0.4.1
+      '@noble/hashes': 2.2.0
+      '@noble/post-quantum': 0.5.4
+      fp-ts: 2.16.11
+      io-ts: 2.2.22(fp-ts@2.16.11)
+
+  '@dynamic-labs-wallet/node-evm@1.0.25(@dynamic-labs-wallet/forward-mpc-client@0.10.1(@dynamic-labs-wallet/primitives@1.0.25))(@zerodev/webauthn-key@5.5.0(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)))(typescript@6.0.3)(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@dynamic-labs-sdk/client': 0.3.0
+      '@dynamic-labs-sdk/evm': 0.3.0(typescript@6.0.3)(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))(zod@4.4.3)
+      '@dynamic-labs-sdk/zerodev': 0.3.0(@zerodev/webauthn-key@5.5.0(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)))(typescript@6.0.3)(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))(zod@4.4.3)
+      '@dynamic-labs-wallet/core': 1.0.25(@dynamic-labs-wallet/forward-mpc-client@0.10.1(@dynamic-labs-wallet/primitives@1.0.25))
+      '@dynamic-labs-wallet/node': 1.0.25
+      '@dynamic-labs/sdk-api-core': 0.0.984
+      '@zerodev/ecdsa-validator': 5.4.9(@zerodev/sdk@5.4.36(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)))(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))
+      '@zerodev/sdk': 5.4.36(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))
+      viem: 2.50.4(typescript@6.0.3)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@dynamic-labs-wallet/forward-mpc-client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@zerodev/webauthn-key'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@dynamic-labs-wallet/node@1.0.25':
+    dependencies:
+      '@dynamic-labs-wallet/core': 1.0.25(@dynamic-labs-wallet/forward-mpc-client@0.10.1(@dynamic-labs-wallet/primitives@1.0.25))
+      '@dynamic-labs-wallet/forward-mpc-client': 0.10.1(@dynamic-labs-wallet/primitives@1.0.25)
+      '@dynamic-labs-wallet/primitives': 1.0.25
+      '@dynamic-labs/logger': 4.88.3
+      '@dynamic-labs/sdk-api-core': 0.0.984
+      '@noble/hashes': 1.7.1
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@dynamic-labs-wallet/primitives@1.0.25': {}
+
+  '@dynamic-labs/assert-package-version@4.88.3':
+    dependencies:
+      '@dynamic-labs/logger': 4.88.3
+
+  '@dynamic-labs/logger@4.88.3':
+    dependencies:
+      eventemitter3: 5.0.1
+
+  '@dynamic-labs/message-transport@4.88.3':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.88.3
+      '@dynamic-labs/logger': 4.88.3
+      '@dynamic-labs/utils': 4.88.3
+      '@vue/reactivity': 3.5.34
+      eventemitter3: 5.0.1
+
+  '@dynamic-labs/sdk-api-core@0.0.1015': {}
+
+  '@dynamic-labs/sdk-api-core@0.0.764': {}
+
+  '@dynamic-labs/sdk-api-core@0.0.818': {}
+
+  '@dynamic-labs/sdk-api-core@0.0.828': {}
+
+  '@dynamic-labs/sdk-api-core@0.0.860': {}
+
+  '@dynamic-labs/sdk-api-core@0.0.984': {}
+
+  '@dynamic-labs/types@4.88.3':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.88.3
+      '@dynamic-labs/sdk-api-core': 0.0.1015
+
+  '@dynamic-labs/utils@4.88.3':
+    dependencies:
+      '@dynamic-labs/assert-package-version': 4.88.3
+      '@dynamic-labs/logger': 4.88.3
+      '@dynamic-labs/sdk-api-core': 0.0.1015
+      '@dynamic-labs/types': 4.88.3
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      tldts: 6.0.16
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@ethereumjs/rlp@4.0.1': {}
+
+  '@ethereumjs/util@8.1.0':
+    dependencies:
+      '@ethereumjs/rlp': 4.0.1
+      ethereum-cryptography: 2.2.1
+      micro-ftch: 0.3.1
+
+  '@evervault/wasm-attestation-bindings@0.3.1': {}
+
+  '@langchain/anthropic@1.4.0(@langchain/core@1.1.47(ws@8.20.1))':
+    dependencies:
+      '@anthropic-ai/sdk': 0.95.2(zod@4.4.3)
+      '@langchain/core': 1.1.47(ws@8.20.1)
+      zod: 4.4.3
+
+  '@langchain/core@1.1.47(ws@8.20.1)':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.7.1(ws@8.20.1)
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.47(ws@8.20.1))':
+    dependencies:
+      '@langchain/core': 1.1.47(ws@8.20.1)
+      uuid: 10.0.0
+
+  '@langchain/langgraph-sdk@1.9.4(@langchain/core@1.1.47(ws@8.20.1))':
+    dependencies:
+      '@langchain/core': 1.1.47(ws@8.20.1)
+      '@langchain/protocol': 0.0.15
+      '@types/json-schema': 7.0.15
+      p-queue: 9.3.0
+      p-retry: 7.1.1
+      uuid: 13.0.2
+
+  '@langchain/langgraph@1.3.2(@langchain/core@1.1.47(ws@8.20.1))(zod@4.4.3)':
+    dependencies:
+      '@langchain/core': 1.1.47(ws@8.20.1)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.47(ws@8.20.1))
+      '@langchain/langgraph-sdk': 1.9.4(@langchain/core@1.1.47(ws@8.20.1))
+      '@langchain/protocol': 0.0.15
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - svelte
+      - vue
+
+  '@langchain/protocol@0.0.15': {}
+
+  '@msgpack/msgpack@3.1.2': {}
+
+  '@noble/ciphers@0.4.1': {}
+
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.4.2':
+    dependencies:
+      '@noble/hashes': 1.4.0
+
+  '@noble/curves@1.8.0':
+    dependencies:
+      '@noble/hashes': 1.7.0
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/curves@1.9.2':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/curves@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+
+  '@noble/hashes@1.4.0': {}
+
+  '@noble/hashes@1.7.0': {}
+
+  '@noble/hashes@1.7.1': {}
+
+  '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.0.1': {}
+
+  '@noble/hashes@2.2.0': {}
+
+  '@noble/post-quantum@0.5.4':
+    dependencies:
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+
+  '@scure/base@1.1.9': {}
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.4.0':
+    dependencies:
+      '@noble/curves': 1.4.2
+      '@noble/hashes': 1.4.0
+      '@scure/base': 1.1.9
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.3.0':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      '@scure/base': 1.1.9
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@simplewebauthn/browser@13.1.0': {}
+
+  '@simplewebauthn/browser@8.3.7':
+    dependencies:
+      '@simplewebauthn/typescript-types': 8.3.4
+
+  '@simplewebauthn/browser@9.0.1':
+    dependencies:
+      '@simplewebauthn/types': 9.0.1
+
+  '@simplewebauthn/types@12.0.0': {}
+
+  '@simplewebauthn/types@9.0.1': {}
+
+  '@simplewebauthn/typescript-types@8.3.4': {}
+
+  '@stablelib/base64@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@vue/reactivity@3.5.34':
+    dependencies:
+      '@vue/shared': 3.5.34
+
+  '@vue/shared@3.5.34': {}
+
+  '@walletconnect/core@2.21.8(typescript@6.0.3)(zod@4.0.5)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.21.8
+      '@walletconnect/utils': 2.21.8(typescript@6.0.3)(zod@4.0.5)
+      '@walletconnect/window-getters': 1.0.1
+      es-toolkit: 1.39.3
+      events: 3.3.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/environment@1.0.1':
+    dependencies:
+      tslib: 1.14.1
+
+  '@walletconnect/events@1.0.1':
+    dependencies:
+      keyvaluestorage-interface: 1.0.0
+      tslib: 1.14.1
+
+  '@walletconnect/heartbeat@1.2.2':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/time': 1.0.2
+      events: 3.3.0
+
+  '@walletconnect/jsonrpc-provider@1.0.14':
+    dependencies:
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/safe-json': 1.0.2
+      events: 3.3.0
+
+  '@walletconnect/jsonrpc-types@1.0.4':
+    dependencies:
+      events: 3.3.0
+      keyvaluestorage-interface: 1.0.0
+
+  '@walletconnect/jsonrpc-utils@1.0.8':
+    dependencies:
+      '@walletconnect/environment': 1.0.1
+      '@walletconnect/jsonrpc-types': 1.0.4
+      tslib: 1.14.1
+
+  '@walletconnect/jsonrpc-ws-connection@1.0.16':
+    dependencies:
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/safe-json': 1.0.2
+      events: 3.3.0
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@walletconnect/keyvaluestorage@1.1.1':
+    dependencies:
+      '@walletconnect/safe-json': 1.0.2
+      idb-keyval: 6.2.2
+      unstorage: 1.17.5(idb-keyval@6.2.2)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - uploadthing
+
+  '@walletconnect/logger@2.1.2':
+    dependencies:
+      '@walletconnect/safe-json': 1.0.2
+      pino: 7.11.0
+
+  '@walletconnect/relay-api@1.0.11':
+    dependencies:
+      '@walletconnect/jsonrpc-types': 1.0.4
+
+  '@walletconnect/relay-auth@1.1.0':
+    dependencies:
+      '@noble/curves': 1.8.0
+      '@noble/hashes': 1.7.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      uint8arrays: 3.1.1
+
+  '@walletconnect/safe-json@1.0.2':
+    dependencies:
+      tslib: 1.14.1
+
+  '@walletconnect/sign-client@2.21.8(typescript@6.0.3)(zod@4.0.5)':
+    dependencies:
+      '@walletconnect/core': 2.21.8(typescript@6.0.3)(zod@4.0.5)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.21.8
+      '@walletconnect/utils': 2.21.8(typescript@6.0.3)(zod@4.0.5)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/time@1.0.2':
+    dependencies:
+      tslib: 1.14.1
+
+  '@walletconnect/types@2.21.8':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - uploadthing
+
+  '@walletconnect/utils@2.21.8(typescript@6.0.3)(zod@4.0.5)':
+    dependencies:
+      '@msgpack/msgpack': 3.1.2
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.2
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.21.8
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      blakejs: 1.2.1
+      bs58: 6.0.0
+      detect-browser: 5.3.0
+      query-string: 7.1.3
+      uint8arrays: 3.1.1
+      viem: 2.31.0(typescript@6.0.3)(zod@4.0.5)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/utils@2.21.8(typescript@6.0.3)(zod@4.4.3)':
+    dependencies:
+      '@msgpack/msgpack': 3.1.2
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.2
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.21.8
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      blakejs: 1.2.1
+      bs58: 6.0.0
+      detect-browser: 5.3.0
+      query-string: 7.1.3
+      uint8arrays: 3.1.1
+      viem: 2.31.0(typescript@6.0.3)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/window-getters@1.0.1':
+    dependencies:
+      tslib: 1.14.1
+
+  '@walletconnect/window-metadata@1.0.1':
+    dependencies:
+      '@walletconnect/window-getters': 1.0.1
+      tslib: 1.14.1
+
+  '@zerodev/ecdsa-validator@5.4.9(@zerodev/sdk@5.4.36(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)))(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))':
+    dependencies:
+      '@zerodev/sdk': 5.4.36(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))
+      viem: 2.50.4(typescript@6.0.3)(zod@4.4.3)
+
+  '@zerodev/multi-chain-ecdsa-validator@5.4.5(@zerodev/sdk@5.4.36(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)))(@zerodev/webauthn-key@5.5.0(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)))(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))':
+    dependencies:
+      '@simplewebauthn/browser': 9.0.1
+      '@simplewebauthn/typescript-types': 8.3.4
+      '@zerodev/sdk': 5.4.36(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))
+      '@zerodev/webauthn-key': 5.5.0(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))
+      merkletreejs: 0.3.11
+      viem: 2.50.4(typescript@6.0.3)(zod@4.4.3)
+
+  '@zerodev/sdk@5.4.36(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))':
+    dependencies:
+      semver: 7.8.0
+      viem: 2.50.4(typescript@6.0.3)(zod@4.4.3)
+
+  '@zerodev/webauthn-key@5.5.0(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@simplewebauthn/browser': 8.3.7
+      '@simplewebauthn/types': 12.0.0
+      viem: 2.50.4(typescript@6.0.3)(zod@4.4.3)
+
+  abitype@1.0.8(typescript@6.0.3)(zod@4.0.5):
+    optionalDependencies:
+      typescript: 6.0.3
+      zod: 4.0.5
+
+  abitype@1.0.8(typescript@6.0.3)(zod@4.4.3):
+    optionalDependencies:
+      typescript: 6.0.3
+      zod: 4.4.3
+
+  abitype@1.2.3(typescript@6.0.3)(zod@4.0.5):
+    optionalDependencies:
+      typescript: 6.0.3
+      zod: 4.0.5
+
+  abitype@1.2.3(typescript@6.0.3)(zod@4.4.3):
+    optionalDependencies:
+      typescript: 6.0.3
+      zod: 4.4.3
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  argon2id@1.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  atomic-sleep@1.0.0: {}
+
+  axios@1.13.2:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.16.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.9.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  base-x@5.0.1: {}
+
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.3.1: {}
+
+  blakejs@1.2.1: {}
+
+  bn.js@4.11.6: {}
+
+  bn.js@5.2.3: {}
+
+  bs58@6.0.0:
+    dependencies:
+      base-x: 5.0.1
+
+  buffer-reverse@1.0.1: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  cookie-es@1.2.3: {}
+
+  crossws@0.3.5:
+    dependencies:
+      uncrypto: 0.1.3
+
+  crypto-js@4.2.0: {}
+
+  decode-uri-component@0.2.2: {}
+
+  defu@6.1.7: {}
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
+
+  destr@2.0.5: {}
+
+  detect-browser@5.3.0: {}
+
+  dotenv@17.4.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  es-toolkit@1.39.3: {}
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  ethereum-bloom-filters@1.2.0:
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  ethereum-cryptography@2.2.1:
+    dependencies:
+      '@noble/curves': 1.4.2
+      '@noble/hashes': 1.4.0
+      '@scure/bip32': 1.4.0
+      '@scure/bip39': 1.3.0
+
+  ethjs-unit@0.1.6:
+    dependencies:
+      bn.js: 4.11.6
+      number-to-bn: 1.7.0
+
+  eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.1: {}
+
+  eventemitter3@5.0.4: {}
+
+  events@3.3.0: {}
+
+  fast-redact@3.5.0: {}
+
+  fast-sha256@1.3.0: {}
+
+  filter-obj@1.1.0: {}
+
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  fp-ts@2.16.11: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  h3@1.15.11:
+    dependencies:
+      cookie-es: 1.2.3
+      crossws: 0.3.5
+      defu: 6.1.7
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.4
+      radix3: 1.1.2
+      ufo: 1.6.4
+      uncrypto: 0.1.3
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  idb-keyval@6.2.2: {}
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  io-ts@2.2.22(fp-ts@2.16.11):
+    dependencies:
+      fp-ts: 2.16.11
+
+  iron-webcrypto@1.2.1: {}
+
+  is-hex-prefixed@1.0.0: {}
+
+  is-network-error@1.3.2: {}
+
+  isows@1.0.7(ws@8.18.2):
+    dependencies:
+      ws: 8.18.2
+
+  isows@1.0.7(ws@8.20.1):
+    dependencies:
+      ws: 8.20.1
+
+  js-tiktoken@1.0.21:
+    dependencies:
+      base64-js: 1.5.1
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
+  keyvaluestorage-interface@1.0.0: {}
+
+  langsmith@0.7.1(ws@8.20.1):
+    dependencies:
+      p-queue: 6.6.2
+    optionalDependencies:
+      ws: 8.20.1
+
+  lru-cache@11.5.0: {}
+
+  math-intrinsics@1.1.0: {}
+
+  merkletreejs@0.3.11:
+    dependencies:
+      bignumber.js: 9.3.1
+      buffer-reverse: 1.0.1
+      crypto-js: 4.2.0
+      treeify: 1.1.0
+      web3-utils: 1.10.4
+
+  micro-ftch@0.3.1: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  multiformats@9.9.0: {}
+
+  mustache@4.2.0: {}
+
+  node-fetch-native@1.6.7: {}
+
+  node-mock-http@1.0.4: {}
+
+  normalize-path@3.0.0: {}
+
+  number-to-bn@1.7.0:
+    dependencies:
+      bn.js: 4.11.6
+      strip-hex-prefix: 1.0.0
+
+  ofetch@1.5.1:
+    dependencies:
+      destr: 2.0.5
+      node-fetch-native: 1.6.7
+      ufo: 1.6.4
+
+  on-exit-leak-free@0.2.0: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  ox@0.14.22(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.7.1(typescript@6.0.3)(zod@4.0.5):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.3)(zod@4.0.5)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.7.1(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - zod
+
+  p-finally@1.0.0: {}
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-queue@9.3.0:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.2
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
+
+  p-timeout@7.0.1: {}
+
+  picomatch@2.3.2: {}
+
+  pino-abstract-transport@0.5.0:
+    dependencies:
+      duplexify: 4.1.3
+      split2: 4.2.0
+
+  pino-std-serializers@4.0.0: {}
+
+  pino@7.11.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.5.0
+      on-exit-leak-free: 0.2.0
+      pino-abstract-transport: 0.5.0
+      pino-std-serializers: 4.0.0
+      process-warning: 1.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.1.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 2.8.0
+      thread-stream: 0.15.2
+
+  process-warning@1.0.0: {}
+
+  proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
+
+  query-string@7.1.3:
+    dependencies:
+      decode-uri-component: 0.2.2
+      filter-obj: 1.1.0
+      split-on-first: 1.1.0
+      strict-uri-encode: 2.0.0
+
+  quick-format-unescaped@4.0.4: {}
+
+  radix3@1.1.2: {}
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  readdirp@5.0.0: {}
+
+  real-require@0.1.0: {}
+
+  safe-buffer@5.2.1: {}
+
+  safe-stable-stringify@2.5.0: {}
+
+  semver@7.8.0: {}
+
+  setprototypeof@1.2.0: {}
+
+  sonic-boom@2.8.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  split-on-first@1.1.0: {}
+
+  split2@4.2.0: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
+  statuses@2.0.1: {}
+
+  stream-shift@1.0.3: {}
+
+  strict-uri-encode@2.0.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-hex-prefix@1.0.0:
+    dependencies:
+      is-hex-prefixed: 1.0.0
+
+  thread-stream@0.15.2:
+    dependencies:
+      real-require: 0.1.0
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.0.16:
+    dependencies:
+      tldts-core: 6.1.86
+
+  toidentifier@1.0.1: {}
+
+  treeify@1.1.0: {}
+
+  ts-algebra@2.0.0: {}
+
+  tslib@1.14.1: {}
+
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@6.0.3: {}
+
+  ufo@1.6.4: {}
+
+  uint8arrays@3.1.1:
+    dependencies:
+      multiformats: 9.9.0
+
+  uncrypto@0.1.3: {}
+
+  undici-types@7.24.6: {}
+
+  unstorage@1.17.5(idb-keyval@6.2.2):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.5.0
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+    optionalDependencies:
+      idb-keyval: 6.2.2
+
+  utf8@3.0.0: {}
+
+  util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
+
+  uuid@11.1.0: {}
+
+  uuid@13.0.2: {}
+
+  viem@2.31.0(typescript@6.0.3)(zod@4.0.5):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@6.0.3)(zod@4.0.5)
+      isows: 1.0.7(ws@8.18.2)
+      ox: 0.7.1(typescript@6.0.3)(zod@4.0.5)
+      ws: 8.18.2
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.31.0(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@6.0.3)(zod@4.4.3)
+      isows: 1.0.7(ws@8.18.2)
+      ox: 0.7.1(typescript@6.0.3)(zod@4.4.3)
+      ws: 8.18.2
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.50.4(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
+      isows: 1.0.7(ws@8.20.1)
+      ox: 0.14.22(typescript@6.0.3)(zod@4.4.3)
+      ws: 8.20.1
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  web3-utils@1.10.4:
+    dependencies:
+      '@ethereumjs/util': 8.1.0
+      bn.js: 5.2.3
+      ethereum-bloom-filters: 1.2.0
+      ethereum-cryptography: 2.2.1
+      ethjs-unit: 0.1.6
+      number-to-bn: 1.7.0
+      randombytes: 2.1.0
+      utf8: 3.0.0
+
+  wrappy@1.0.2: {}
+
+  ws@7.5.10: {}
+
+  ws@8.18.2: {}
+
+  ws@8.20.1: {}
+
+  zod@4.0.5: {}
+
+  zod@4.4.3: {}

--- a/examples/nodejs-langgraph-agent/src/agent.ts
+++ b/examples/nodejs-langgraph-agent/src/agent.ts
@@ -1,18 +1,18 @@
 import { ChatAnthropic } from "@langchain/anthropic";
-import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { createAgent } from "langchain";
 import { HumanMessage } from "@langchain/core/messages";
 import { MemorySaver } from "@langchain/langgraph";
 import { allTools } from "./tools.js";
 
 const SYSTEM_PROMPT =
-  "You are a Web3 assistant with access to the user's delegated EVM wallet via Dynamic MPC.\n\n" +
+  "You are a Web3 assistant with access to an agent-owned EVM wallet via Dynamic server-side MPC.\n\n" +
   "## The agent wallet\n" +
-  "There is one wallet: the user's delegated wallet — their real wallet they have granted " +
-  "you signing access to. Use list_wallets to get the address. When the user says 'my wallet' " +
-  "or 'the wallet', this is it. The same address works on every EVM chain.\n\n" +
+  "There is one wallet: the agent's own server wallet, created and held server-side by this agent. " +
+  "Use list_wallets to get the address. When the user says 'my wallet' or 'the wallet', this is it. " +
+  "The same address works on every EVM chain.\n\n" +
   "## Capabilities\n" +
-  "- get_token_balances: check balances across EVM chains (Dynamic balances API). " +
-  "Pass includePrices=true for USD values.\n" +
+  "- get_token_balances: check native token balances across EVM chains (on-chain RPC). " +
+  "Pass networkId to filter to a specific chain.\n" +
   "- send_transaction: send a native transfer. The user is always prompted to confirm " +
   "before anything is broadcast.\n\n" +
   "## Rules\n" +
@@ -21,15 +21,15 @@ const SYSTEM_PROMPT =
   "- Never invent balances or transaction hashes — only report tool results.";
 
 // Built lazily on first use so startup credential checks run (and report) first.
-let _agent: ReturnType<typeof createReactAgent> | null = null;
+let _agent: ReturnType<typeof createAgent> | null = null;
 
 function getAgent() {
   if (!_agent) {
-    _agent = createReactAgent({
-      llm: new ChatAnthropic({ model: "claude-haiku-4-5-20251001", temperature: 0 }),
+    _agent = createAgent({
+      model: new ChatAnthropic({ model: "claude-haiku-4-5-20251001", temperature: 0 }),
       tools: allTools,
-      checkpointSaver: new MemorySaver(),
-      stateModifier: SYSTEM_PROMPT,
+      checkpointer: new MemorySaver(),
+      systemPrompt: SYSTEM_PROMPT,
     });
   }
   return _agent;

--- a/examples/nodejs-langgraph-agent/src/agent.ts
+++ b/examples/nodejs-langgraph-agent/src/agent.ts
@@ -1,0 +1,48 @@
+import { ChatAnthropic } from "@langchain/anthropic";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { HumanMessage } from "@langchain/core/messages";
+import { MemorySaver } from "@langchain/langgraph";
+import { allTools } from "./tools.js";
+
+const SYSTEM_PROMPT =
+  "You are a Web3 assistant with access to the user's delegated EVM wallet via Dynamic MPC.\n\n" +
+  "## The agent wallet\n" +
+  "There is one wallet: the user's delegated wallet — their real wallet they have granted " +
+  "you signing access to. Use list_wallets to get the address. When the user says 'my wallet' " +
+  "or 'the wallet', this is it. The same address works on every EVM chain.\n\n" +
+  "## Capabilities\n" +
+  "- get_token_balances: check balances across EVM chains (Dynamic balances API). " +
+  "Pass includePrices=true for USD values.\n" +
+  "- send_transaction: send a native transfer. The user is always prompted to confirm " +
+  "before anything is broadcast.\n\n" +
+  "## Rules\n" +
+  "- Mainnet only — no testnets.\n" +
+  "- Always resolve the wallet address with list_wallets before acting on 'my wallet'.\n" +
+  "- Never invent balances or transaction hashes — only report tool results.";
+
+// Built lazily on first use so startup credential checks run (and report) first.
+let _agent: ReturnType<typeof createReactAgent> | null = null;
+
+function getAgent() {
+  if (!_agent) {
+    _agent = createReactAgent({
+      llm: new ChatAnthropic({ model: "claude-haiku-4-5-20251001", temperature: 0 }),
+      tools: allTools,
+      checkpointSaver: new MemorySaver(),
+      stateModifier: SYSTEM_PROMPT,
+    });
+  }
+  return _agent;
+}
+
+export async function runAgent(
+  userMessage: string,
+  threadId: string = "default"
+): Promise<string> {
+  const result = await getAgent().invoke(
+    { messages: [new HumanMessage(userMessage)] },
+    { configurable: { thread_id: threadId } }
+  );
+  const last = result.messages[result.messages.length - 1];
+  return typeof last.content === "string" ? last.content : JSON.stringify(last.content);
+}

--- a/examples/nodejs-langgraph-agent/src/confirm.ts
+++ b/examples/nodejs-langgraph-agent/src/confirm.ts
@@ -1,4 +1,4 @@
-import type readline from "readline";
+import type readline from "node:readline";
 
 // ─── Shared readline instance ─────────────────────────────────────────────────
 

--- a/examples/nodejs-langgraph-agent/src/confirm.ts
+++ b/examples/nodejs-langgraph-agent/src/confirm.ts
@@ -1,0 +1,37 @@
+import type readline from "readline";
+
+// ─── Shared readline instance ─────────────────────────────────────────────────
+
+let _rl: readline.Interface | null = null;
+
+export function setReadlineForConfirm(rl: readline.Interface): void {
+  _rl = rl;
+}
+
+// ─── Confirmation prompt ──────────────────────────────────────────────────────
+
+const WIDTH = 58;
+
+/** Prompts the user to confirm a sensitive action. Defaults to deny. */
+export async function confirm(summary: string): Promise<boolean> {
+  const bar = "─".repeat(WIDTH);
+
+  process.stdout.write(`\n┌─ ACTION REQUIRED ${bar.slice(18)}\n`);
+  for (const line of summary.split("\n")) {
+    process.stdout.write(`│  ${line}\n`);
+  }
+  process.stdout.write(`└${bar}\n`);
+
+  return new Promise((resolve) => {
+    if (!_rl) {
+      process.stdout.write("No readline available — action denied.\n");
+      resolve(false);
+      return;
+    }
+    _rl.question("Proceed? [y/N] ", (answer) => {
+      const confirmed = answer.trim().toLowerCase() === "y";
+      if (!confirmed) process.stdout.write("Cancelled.\n");
+      resolve(confirmed);
+    });
+  });
+}

--- a/examples/nodejs-langgraph-agent/src/index.ts
+++ b/examples/nodejs-langgraph-agent/src/index.ts
@@ -1,21 +1,14 @@
 import "dotenv/config";
-import readline from "readline";
-import { loadDelegationCredentials } from "./wallet.js";
+import readline from "node:readline";
+import { initServerWallet } from "./wallet.js";
 import { setAgentWallet } from "./tools.js";
 import { runAgent } from "./agent.js";
 import { setReadlineForConfirm } from "./confirm.js";
 
-// ─── Load the delegated agent wallet ─────────────────────────────────────────
+// ─── Initialize the agent's server wallet ────────────────────────────────────
 
-const creds = loadDelegationCredentials();
-if (!creds) {
-  console.error(
-    "No delegation credentials found. Set DELEGATED_WALLET_ID, DELEGATED_WALLET_ADDRESS, " +
-      "DELEGATED_WALLET_API_KEY and DELEGATED_KEY_SHARE in your .env (see .example.env)."
-  );
-  process.exit(1);
-}
-setAgentWallet(creds);
+const wallet = await initServerWallet();
+setAgentWallet(wallet);
 
 // ─── Interactive REPL ─────────────────────────────────────────────────────────
 
@@ -24,7 +17,7 @@ console.log("  Dynamic + LangGraph bare-bones agent");
 console.log("=".repeat(60));
 console.log("Example commands:");
 console.log('  "show my wallet"');
-console.log('  "what are my token balances with prices"');
+console.log('  "what are my token balances"');
 console.log('  "send 0.001 ETH on ethereum to 0x..."');
 console.log("  Type 'exit' to quit\n");
 

--- a/examples/nodejs-langgraph-agent/src/index.ts
+++ b/examples/nodejs-langgraph-agent/src/index.ts
@@ -1,0 +1,58 @@
+import "dotenv/config";
+import readline from "readline";
+import { loadDelegationCredentials } from "./wallet.js";
+import { setAgentWallet } from "./tools.js";
+import { runAgent } from "./agent.js";
+import { setReadlineForConfirm } from "./confirm.js";
+
+// ─── Load the delegated agent wallet ─────────────────────────────────────────
+
+const creds = loadDelegationCredentials();
+if (!creds) {
+  console.error(
+    "No delegation credentials found. Set DELEGATED_WALLET_ID, DELEGATED_WALLET_ADDRESS, " +
+      "DELEGATED_WALLET_API_KEY and DELEGATED_KEY_SHARE in your .env (see .example.env)."
+  );
+  process.exit(1);
+}
+setAgentWallet(creds);
+
+// ─── Interactive REPL ─────────────────────────────────────────────────────────
+
+console.log("=".repeat(60));
+console.log("  Dynamic + LangGraph bare-bones agent");
+console.log("=".repeat(60));
+console.log("Example commands:");
+console.log('  "show my wallet"');
+console.log('  "what are my token balances with prices"');
+console.log('  "send 0.001 ETH on ethereum to 0x..."');
+console.log("  Type 'exit' to quit\n");
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+setReadlineForConfirm(rl);
+
+const threadId = "interactive-session";
+
+function prompt(question: string): Promise<string> {
+  return new Promise((resolve) => rl.question(question, resolve));
+}
+
+rl.on("close", () => {
+  console.log("\nGoodbye!");
+  process.exit(0);
+});
+
+while (true) {
+  const input = (await prompt("You: ")).trim();
+  if (!input) continue;
+  if (input.toLowerCase() === "exit" || input.toLowerCase() === "quit") {
+    rl.close();
+    break;
+  }
+  try {
+    const response = await runAgent(input, threadId);
+    console.log(`\nAgent: ${response}\n`);
+  } catch (err: any) {
+    console.error(`\nError: ${err?.message ?? String(err)}\n`);
+  }
+}

--- a/examples/nodejs-langgraph-agent/src/tools.ts
+++ b/examples/nodejs-langgraph-agent/src/tools.ts
@@ -1,0 +1,206 @@
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+import { isAddress, parseEther, formatEther } from "viem";
+import { confirm } from "./confirm.js";
+import {
+  getChainById,
+  sendTransactionDelegated,
+  type DelegationCredentials,
+} from "./wallet.js";
+
+// ─── Agent wallet (set once at startup) ──────────────────────────────────────
+
+let agentWallet: DelegationCredentials | null = null;
+
+export function setAgentWallet(creds: DelegationCredentials): void {
+  agentWallet = creds;
+  console.log(`[agent-wallet] Loaded delegated wallet: ${creds.walletAddress}`);
+}
+
+function requireWallet(): DelegationCredentials {
+  if (!agentWallet) {
+    throw new Error("No agent wallet loaded. Set delegation credentials in .env.");
+  }
+  return agentWallet;
+}
+
+function toolError(err: unknown): string {
+  return JSON.stringify({
+    success: false,
+    error: err instanceof Error ? err.message : String(err),
+  });
+}
+
+// ─── list_wallets ─────────────────────────────────────────────────────────────
+
+export const listWalletsTool = tool(
+  async () => {
+    if (!agentWallet) {
+      return JSON.stringify({ wallets: [], message: "No agent wallet loaded" });
+    }
+    return JSON.stringify({
+      wallets: [
+        {
+          label: "agent",
+          address: agentWallet.walletAddress,
+          type: "delegated (user's wallet)",
+        },
+      ],
+    });
+  },
+  {
+    name: "list_wallets",
+    description: "Show the agent's delegated wallet address.",
+    schema: z.object({}),
+  }
+);
+
+// ─── get_token_balances (Dynamic multi-chain balances API) ───────────────────
+
+export const getTokenBalancesTool = tool(
+  async ({ chainName, networkId, includePrices }) => {
+    try {
+      const wallet = requireWallet();
+      const environmentId = process.env.DYNAMIC_ENVIRONMENT_ID;
+      const userJwt = process.env.DYNAMIC_USER_JWT;
+      if (!environmentId || !userJwt) {
+        return toolError(new Error("DYNAMIC_ENVIRONMENT_ID or DYNAMIC_USER_JWT not set"));
+      }
+
+      const chain = chainName?.toUpperCase() ?? "EVM";
+
+      // Decode the JWT payload to extract the session public key (no verification).
+      let sessionPublicKey: string | undefined;
+      try {
+        const payload = JSON.parse(
+          Buffer.from(userJwt.split(".")[1], "base64url").toString("utf8")
+        );
+        sessionPublicKey = payload.session_public_key;
+      } catch {
+        // not fatal — header is optional
+      }
+
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${userJwt}`,
+        "Content-Type": "application/json",
+      };
+      if (sessionPublicKey) headers["x-dyn-session-public-key"] = sessionPublicKey;
+
+      // The balances API requires a networkId; fan out across popular EVM chains
+      // when none is specified.
+      const networkIds = networkId ? [networkId] : [1, 137, 8453, 42161, 56, 10];
+
+      const fetchForNetwork = async (netId: number) => {
+        const url = new URL(
+          `https://app.dynamicauth.com/api/v0/sdk/${environmentId}/chains/${chain}/balances`
+        );
+        url.searchParams.set("accountAddress", wallet.walletAddress);
+        url.searchParams.set("includeNative", "true");
+        url.searchParams.set("filterSpamTokens", "true");
+        url.searchParams.set("networkId", String(netId));
+        if (includePrices) url.searchParams.set("includePrices", "true");
+
+        const res = await fetch(url.toString(), { headers });
+        if (!res.ok) return [];
+        const data = await res.json();
+        return Array.isArray(data) ? data : [];
+      };
+
+      const items = (await Promise.all(networkIds.map(fetchForNetwork))).flat();
+
+      return JSON.stringify({
+        success: true,
+        address: wallet.walletAddress,
+        chain,
+        networkId: networkId ?? "all",
+        tokens: items.map((t: any) => ({
+          name: t.name,
+          symbol: t.symbol,
+          balance: t.balance,
+          networkId: t.networkId,
+          ...(t.price != null && { priceUsd: t.price }),
+          ...(t.marketValue != null && { valueUsd: t.marketValue }),
+          isNative: t.isNative ?? false,
+        })),
+      });
+    } catch (err) {
+      return toolError(err);
+    }
+  },
+  {
+    name: "get_token_balances",
+    description:
+      "Get token balances for the agent's delegated wallet using Dynamic's multi-chain " +
+      "balances API. Use networkId to filter to a specific chain (e.g. 1 = Ethereum, " +
+      "137 = Polygon, 8453 = Base). Pass includePrices=true for USD values.",
+    schema: z.object({
+      chainName: z
+        .string()
+        .optional()
+        .describe("Chain type: ETH, EVM, SOL, BTC, etc. Defaults to EVM."),
+      networkId: z
+        .number()
+        .optional()
+        .describe("Specific network ID (1 = Ethereum, 137 = Polygon, 8453 = Base)"),
+      includePrices: z
+        .boolean()
+        .optional()
+        .describe("Include USD prices and market values"),
+    }),
+  }
+);
+
+// ─── send_transaction (signs via Dynamic MPC, gated by a confirm prompt) ─────
+
+export const sendTransactionTool = tool(
+  async ({ to, amountEth, chainId }) => {
+    try {
+      const wallet = requireWallet();
+      if (!isAddress(to)) {
+        return toolError(new Error(`"${to}" is not a valid EVM address`));
+      }
+
+      const value = parseEther(amountEth);
+      const chain = getChainById(chainId);
+
+      const ok = await confirm(
+        `Send native transfer\n` +
+          `  Chain:  ${chain.name} (${chainId})\n` +
+          `  From:   ${wallet.walletAddress}\n` +
+          `  To:     ${to}\n` +
+          `  Amount: ${formatEther(value)} ${chain.nativeCurrency.symbol}`
+      );
+      if (!ok) {
+        return JSON.stringify({ success: false, error: "User declined the transaction" });
+      }
+
+      const hash = await sendTransactionDelegated(
+        wallet,
+        chainId,
+        to as `0x${string}`,
+        value
+      );
+      return JSON.stringify({ success: true, transactionHash: hash, chainId });
+    } catch (err) {
+      return toolError(err);
+    }
+  },
+  {
+    name: "send_transaction",
+    description:
+      "Send a native-currency transfer (e.g. ETH, POL) from the agent's delegated wallet. " +
+      "Signs via Dynamic MPC and broadcasts. The user is always prompted to confirm before " +
+      "the transaction is sent.",
+    schema: z.object({
+      to: z.string().describe("Recipient EVM address (0x...)"),
+      amountEth: z
+        .string()
+        .describe("Amount to send, in whole native units (e.g. \"0.01\")"),
+      chainId: z
+        .number()
+        .describe("EVM chain ID (1 = Ethereum, 137 = Polygon, 8453 = Base)"),
+    }),
+  }
+);
+
+export const allTools = [listWalletsTool, getTokenBalancesTool, sendTransactionTool];

--- a/examples/nodejs-langgraph-agent/src/tools.ts
+++ b/examples/nodejs-langgraph-agent/src/tools.ts
@@ -1,25 +1,26 @@
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
-import { isAddress, parseEther, formatEther } from "viem";
+import { isAddress, parseEther, formatEther, createPublicClient, http } from "viem";
 import { confirm } from "./confirm.js";
 import {
   getChainById,
-  sendTransactionDelegated,
-  type DelegationCredentials,
+  sendTransactionServer,
+  SUPPORTED_CHAIN_IDS,
+  type ServerWallet,
 } from "./wallet.js";
 
 // ─── Agent wallet (set once at startup) ──────────────────────────────────────
 
-let agentWallet: DelegationCredentials | null = null;
+let agentWallet: ServerWallet | null = null;
 
-export function setAgentWallet(creds: DelegationCredentials): void {
-  agentWallet = creds;
-  console.log(`[agent-wallet] Loaded delegated wallet: ${creds.walletAddress}`);
+export function setAgentWallet(wallet: ServerWallet): void {
+  agentWallet = wallet;
+  console.log(`[agent-wallet] Loaded server wallet: ${wallet.accountAddress}`);
 }
 
-function requireWallet(): DelegationCredentials {
+function requireWallet(): ServerWallet {
   if (!agentWallet) {
-    throw new Error("No agent wallet loaded. Set delegation credentials in .env.");
+    throw new Error("No agent wallet loaded. Run initServerWallet() at startup.");
   }
   return agentWallet;
 }
@@ -42,86 +43,54 @@ export const listWalletsTool = tool(
       wallets: [
         {
           label: "agent",
-          address: agentWallet.walletAddress,
-          type: "delegated (user's wallet)",
+          address: agentWallet.accountAddress,
+          type: "server (agent-owned MPC wallet)",
         },
       ],
     });
   },
   {
     name: "list_wallets",
-    description: "Show the agent's delegated wallet address.",
+    description: "Show the agent's server wallet address.",
     schema: z.object({}),
   }
 );
 
-// ─── get_token_balances (Dynamic multi-chain balances API) ───────────────────
+// ─── get_token_balances (on-chain via viem) ───────────────────────────────────
 
 export const getTokenBalancesTool = tool(
-  async ({ chainName, networkId, includePrices }) => {
+  async ({ networkId }) => {
     try {
       const wallet = requireWallet();
-      const environmentId = process.env.DYNAMIC_ENVIRONMENT_ID;
-      const userJwt = process.env.DYNAMIC_USER_JWT;
-      if (!environmentId || !userJwt) {
-        return toolError(new Error("DYNAMIC_ENVIRONMENT_ID or DYNAMIC_USER_JWT not set"));
-      }
+      const address = wallet.accountAddress as `0x${string}`;
 
-      const chain = chainName?.toUpperCase() ?? "EVM";
+      const chainIds = networkId ? [networkId] : SUPPORTED_CHAIN_IDS;
 
-      // Decode the JWT payload to extract the session public key (no verification).
-      let sessionPublicKey: string | undefined;
-      try {
-        const payload = JSON.parse(
-          Buffer.from(userJwt.split(".")[1], "base64url").toString("utf8")
-        );
-        sessionPublicKey = payload.session_public_key;
-      } catch {
-        // not fatal — header is optional
-      }
-
-      const headers: Record<string, string> = {
-        Authorization: `Bearer ${userJwt}`,
-        "Content-Type": "application/json",
-      };
-      if (sessionPublicKey) headers["x-dyn-session-public-key"] = sessionPublicKey;
-
-      // The balances API requires a networkId; fan out across popular EVM chains
-      // when none is specified.
-      const networkIds = networkId ? [networkId] : [1, 137, 8453, 42161, 56, 10];
-
-      const fetchForNetwork = async (netId: number) => {
-        const url = new URL(
-          `https://app.dynamicauth.com/api/v0/sdk/${environmentId}/chains/${chain}/balances`
-        );
-        url.searchParams.set("accountAddress", wallet.walletAddress);
-        url.searchParams.set("includeNative", "true");
-        url.searchParams.set("filterSpamTokens", "true");
-        url.searchParams.set("networkId", String(netId));
-        if (includePrices) url.searchParams.set("includePrices", "true");
-
-        const res = await fetch(url.toString(), { headers });
-        if (!res.ok) return [];
-        const data = await res.json();
-        return Array.isArray(data) ? data : [];
+      const fetchBalance = async (chainId: number) => {
+        try {
+          const chain = getChainById(chainId);
+          const client = createPublicClient({ chain, transport: http() });
+          const balance = await client.getBalance({ address });
+          return {
+            networkId: chainId,
+            chainName: chain.name,
+            symbol: chain.nativeCurrency.symbol,
+            balance: formatEther(balance),
+            isNative: true,
+          };
+        } catch {
+          return null;
+        }
       };
 
-      const items = (await Promise.all(networkIds.map(fetchForNetwork))).flat();
+      const results = (await Promise.all(chainIds.map(fetchBalance))).filter(
+        Boolean
+      );
 
       return JSON.stringify({
         success: true,
-        address: wallet.walletAddress,
-        chain,
-        networkId: networkId ?? "all",
-        tokens: items.map((t: any) => ({
-          name: t.name,
-          symbol: t.symbol,
-          balance: t.balance,
-          networkId: t.networkId,
-          ...(t.price != null && { priceUsd: t.price }),
-          ...(t.marketValue != null && { valueUsd: t.marketValue }),
-          isNative: t.isNative ?? false,
-        })),
+        address,
+        tokens: results,
       });
     } catch (err) {
       return toolError(err);
@@ -130,27 +99,22 @@ export const getTokenBalancesTool = tool(
   {
     name: "get_token_balances",
     description:
-      "Get token balances for the agent's delegated wallet using Dynamic's multi-chain " +
-      "balances API. Use networkId to filter to a specific chain (e.g. 1 = Ethereum, " +
-      "137 = Polygon, 8453 = Base). Pass includePrices=true for USD values.",
+      "Get native token balances for the agent's server wallet across EVM chains. " +
+      "Use networkId to filter to a specific chain (e.g. 1 = Ethereum, 137 = Polygon, " +
+      "8453 = Base). Balances are fetched on-chain via RPC.",
     schema: z.object({
-      chainName: z
-        .string()
-        .optional()
-        .describe("Chain type: ETH, EVM, SOL, BTC, etc. Defaults to EVM."),
       networkId: z
         .number()
         .optional()
-        .describe("Specific network ID (1 = Ethereum, 137 = Polygon, 8453 = Base)"),
-      includePrices: z
-        .boolean()
-        .optional()
-        .describe("Include USD prices and market values"),
+        .describe(
+          "Specific network ID (1 = Ethereum, 137 = Polygon, 8453 = Base). " +
+            "Omit to query all supported chains."
+        ),
     }),
   }
 );
 
-// ─── send_transaction (signs via Dynamic MPC, gated by a confirm prompt) ─────
+// ─── send_transaction ─────────────────────────────────────────────────────────
 
 export const sendTransactionTool = tool(
   async ({ to, amountEth, chainId }) => {
@@ -166,7 +130,7 @@ export const sendTransactionTool = tool(
       const ok = await confirm(
         `Send native transfer\n` +
           `  Chain:  ${chain.name} (${chainId})\n` +
-          `  From:   ${wallet.walletAddress}\n` +
+          `  From:   ${wallet.accountAddress}\n` +
           `  To:     ${to}\n` +
           `  Amount: ${formatEther(value)} ${chain.nativeCurrency.symbol}`
       );
@@ -174,7 +138,7 @@ export const sendTransactionTool = tool(
         return JSON.stringify({ success: false, error: "User declined the transaction" });
       }
 
-      const hash = await sendTransactionDelegated(
+      const hash = await sendTransactionServer(
         wallet,
         chainId,
         to as `0x${string}`,
@@ -188,14 +152,14 @@ export const sendTransactionTool = tool(
   {
     name: "send_transaction",
     description:
-      "Send a native-currency transfer (e.g. ETH, POL) from the agent's delegated wallet. " +
+      "Send a native-currency transfer (e.g. ETH, POL) from the agent's server wallet. " +
       "Signs via Dynamic MPC and broadcasts. The user is always prompted to confirm before " +
       "the transaction is sent.",
     schema: z.object({
       to: z.string().describe("Recipient EVM address (0x...)"),
       amountEth: z
         .string()
-        .describe("Amount to send, in whole native units (e.g. \"0.01\")"),
+        .describe('Amount to send, in whole native units (e.g. "0.01")'),
       chainId: z
         .number()
         .describe("EVM chain ID (1 = Ethereum, 137 = Polygon, 8453 = Base)"),

--- a/examples/nodejs-langgraph-agent/src/wallet.ts
+++ b/examples/nodejs-langgraph-agent/src/wallet.ts
@@ -1,29 +1,29 @@
 /**
- * Dynamic delegated MPC wallet support for the agent.
+ * Dynamic server-wallet support for the agent.
  *
- * The user approves delegation in the Dynamic SDK (client-side); Dynamic's
- * webhook delivers (encrypted) credentials to your server. This bare-bones
- * example loads pre-decrypted credentials from the environment and uses
- * Dynamic's MPC signing to sign + broadcast transactions on any EVM chain.
+ * The agent owns its own MPC wallet, created once and persisted to
+ * .wallet-state.json (gitignored). No user JWT or delegation credentials are
+ * required. Signing is performed entirely server-side via Dynamic MPC.
+ *
+ * Security note: .wallet-state.json contains the server key share — treat it
+ * like a private key. Never commit it or expose it to untrusted parties.
  */
 
-import {
-  createDelegatedEvmWalletClient,
-  delegatedSignTransaction,
-  type DelegatedEvmWalletClient,
-} from "@dynamic-labs-wallet/node-evm";
-import type { ServerKeyShare } from "@dynamic-labs-wallet/node";
+import { DynamicEvmWalletClient } from "@dynamic-labs-wallet/node-evm";
+import { ThresholdSignatureScheme } from "@dynamic-labs-wallet/node";
+import type { ServerKeyShare, WalletMetadata } from "@dynamic-labs-wallet/node";
 import { createPublicClient, http } from "viem";
 import { mainnet, polygon, base, arbitrum, optimism, bsc } from "viem/chains";
 import type { Chain, TransactionSerializable } from "viem";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 
-// ─── Types ──────────────────────────────────────────────────────────────────
+// ─── Types ───────────────────────────────────────────────────────────────────
 
-export interface DelegationCredentials {
-  walletId: string;
-  walletAddress: string;
-  walletApiKey: string;
-  keyShare: ServerKeyShare;
+export interface ServerWallet {
+  accountAddress: string;
+  walletMetadata: WalletMetadata;
+  externalServerKeyShares: ServerKeyShare[];
 }
 
 // ─── Chain map ────────────────────────────────────────────────────────────────
@@ -47,69 +47,93 @@ export function getChainById(chainId: number): Chain {
   return chain;
 }
 
-// ─── Credential loading ─────────────────────────────────────────────────────
+export const SUPPORTED_CHAIN_IDS = Object.keys(CHAIN_MAP).map(Number);
 
-/**
- * Loads pre-decrypted delegation credentials from environment variables:
- *   DELEGATED_WALLET_ID, DELEGATED_WALLET_ADDRESS,
- *   DELEGATED_WALLET_API_KEY, DELEGATED_KEY_SHARE (JSON string)
- */
-export function loadDelegationCredentials(): DelegationCredentials | null {
-  const walletId = process.env.DELEGATED_WALLET_ID;
-  const walletAddress = process.env.DELEGATED_WALLET_ADDRESS;
-  const walletApiKey = process.env.DELEGATED_WALLET_API_KEY;
-  const keyShareJson = process.env.DELEGATED_KEY_SHARE;
+// ─── Wallet state persistence ────────────────────────────────────────────────
 
-  if (!walletId || !walletAddress || !walletApiKey || !keyShareJson) {
-    return null;
-  }
+const WALLET_STATE_PATH = join(process.cwd(), ".wallet-state.json");
 
+function loadWalletState(): ServerWallet | null {
+  if (!existsSync(WALLET_STATE_PATH)) return null;
   try {
-    return {
-      walletId,
-      walletAddress,
-      walletApiKey,
-      keyShare: JSON.parse(keyShareJson) as ServerKeyShare,
-    };
+    return JSON.parse(readFileSync(WALLET_STATE_PATH, "utf8")) as ServerWallet;
   } catch {
-    console.warn("[wallet] Failed to parse DELEGATED_KEY_SHARE as JSON");
+    console.warn("[wallet] Failed to parse .wallet-state.json — will recreate");
     return null;
   }
 }
 
-// ─── Delegated client singleton ─────────────────────────────────────────────
-
-let _delegatedClient: DelegatedEvmWalletClient | null = null;
-
-function getDelegatedEvmClient(): DelegatedEvmWalletClient {
-  if (!_delegatedClient) {
-    const environmentId = process.env.DYNAMIC_ENVIRONMENT_ID;
-    const apiKey = process.env.DYNAMIC_API_KEY;
-    if (!environmentId || !apiKey) {
-      throw new Error(
-        "DYNAMIC_ENVIRONMENT_ID and DYNAMIC_API_KEY are required for delegated signing"
-      );
-    }
-    _delegatedClient = createDelegatedEvmWalletClient({ environmentId, apiKey });
-  }
-  return _delegatedClient;
+function saveWalletState(wallet: ServerWallet): void {
+  writeFileSync(WALLET_STATE_PATH, JSON.stringify(wallet, null, 2), { encoding: "utf8", mode: 0o600 });
 }
 
-// ─── Sign + broadcast ───────────────────────────────────────────────────────
+// ─── EVM client singleton ─────────────────────────────────────────────────────
+
+let _evmClient: DynamicEvmWalletClient | null = null;
+
+function getEvmClient(): DynamicEvmWalletClient {
+  if (!_evmClient) {
+    const environmentId = process.env.DYNAMIC_ENVIRONMENT_ID;
+    if (!environmentId) {
+      throw new Error("DYNAMIC_ENVIRONMENT_ID is required");
+    }
+    _evmClient = new DynamicEvmWalletClient({ environmentId });
+  }
+  return _evmClient;
+}
+
+// ─── Init ─────────────────────────────────────────────────────────────────────
 
 /**
- * Signs (via Dynamic MPC) and broadcasts a native-value transfer on the given
- * EVM chain. Returns the transaction hash.
+ * Loads the persisted server wallet or creates a new one on first run.
+ * Authenticates the client with DYNAMIC_API_KEY before any MPC calls.
  */
-export async function sendTransactionDelegated(
-  creds: DelegationCredentials,
+export async function initServerWallet(): Promise<ServerWallet> {
+  const apiKey = process.env.DYNAMIC_API_KEY;
+  if (!apiKey) {
+    throw new Error("DYNAMIC_API_KEY is required");
+  }
+
+  const client = getEvmClient();
+  await client.authenticateApiToken(apiKey);
+
+  const existing = loadWalletState();
+  if (existing) {
+    console.log(`[wallet] Loaded server wallet: ${existing.accountAddress}`);
+    return existing;
+  }
+
+  console.log("[wallet] Creating new server wallet (first run)…");
+  const { walletMetadata, externalServerKeyShares } =
+    await client.createWalletAccount({
+      thresholdSignatureScheme: ThresholdSignatureScheme.TWO_OF_TWO,
+    });
+
+  const wallet: ServerWallet = {
+    accountAddress: walletMetadata.accountAddress,
+    walletMetadata,
+    externalServerKeyShares,
+  };
+  saveWalletState(wallet);
+  console.log(`[wallet] Created server wallet: ${wallet.accountAddress}`);
+  return wallet;
+}
+
+// ─── Sign + broadcast ─────────────────────────────────────────────────────────
+
+/**
+ * Signs (via Dynamic server-side MPC) and broadcasts a native-value transfer.
+ * Returns the transaction hash.
+ */
+export async function sendTransactionServer(
+  wallet: ServerWallet,
   chainId: number,
   to: `0x${string}`,
   value: bigint
 ): Promise<string> {
   const chain = getChainById(chainId);
   const publicClient = createPublicClient({ chain, transport: http() });
-  const address = creds.walletAddress as `0x${string}`;
+  const address = wallet.accountAddress as `0x${string}`;
 
   const nonce = await publicClient.getTransactionCount({ address });
   const block = await publicClient.getBlock({ blockTag: "latest" });
@@ -119,8 +143,12 @@ export async function sendTransactionDelegated(
 
   let gas: bigint;
   try {
-    const estimated = await publicClient.estimateGas({ account: address, to, value });
-    gas = (estimated * 12n) / 10n; // 20% buffer
+    const estimated = await publicClient.estimateGas({
+      account: address,
+      to,
+      value,
+    });
+    gas = (estimated * 12n) / 10n;
   } catch {
     gas = BigInt(21_000);
   }
@@ -136,11 +164,10 @@ export async function sendTransactionDelegated(
     maxPriorityFeePerGas,
   };
 
-  const signedTx = await delegatedSignTransaction(getDelegatedEvmClient(), {
-    walletId: creds.walletId,
-    walletApiKey: creds.walletApiKey,
-    keyShare: creds.keyShare,
+  const signedTx = await getEvmClient().signTransaction({
+    walletMetadata: wallet.walletMetadata,
     transaction,
+    externalServerKeyShares: wallet.externalServerKeyShares,
   });
 
   return publicClient.sendRawTransaction({

--- a/examples/nodejs-langgraph-agent/src/wallet.ts
+++ b/examples/nodejs-langgraph-agent/src/wallet.ts
@@ -1,0 +1,149 @@
+/**
+ * Dynamic delegated MPC wallet support for the agent.
+ *
+ * The user approves delegation in the Dynamic SDK (client-side); Dynamic's
+ * webhook delivers (encrypted) credentials to your server. This bare-bones
+ * example loads pre-decrypted credentials from the environment and uses
+ * Dynamic's MPC signing to sign + broadcast transactions on any EVM chain.
+ */
+
+import {
+  createDelegatedEvmWalletClient,
+  delegatedSignTransaction,
+  type DelegatedEvmWalletClient,
+} from "@dynamic-labs-wallet/node-evm";
+import type { ServerKeyShare } from "@dynamic-labs-wallet/node";
+import { createPublicClient, http } from "viem";
+import { mainnet, polygon, base, arbitrum, optimism, bsc } from "viem/chains";
+import type { Chain, TransactionSerializable } from "viem";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface DelegationCredentials {
+  walletId: string;
+  walletAddress: string;
+  walletApiKey: string;
+  keyShare: ServerKeyShare;
+}
+
+// ─── Chain map ────────────────────────────────────────────────────────────────
+
+const CHAIN_MAP: Record<number, Chain> = {
+  1: mainnet,
+  137: polygon,
+  8453: base,
+  42161: arbitrum,
+  10: optimism,
+  56: bsc,
+};
+
+export function getChainById(chainId: number): Chain {
+  const chain = CHAIN_MAP[chainId];
+  if (!chain) {
+    throw new Error(
+      `Unsupported chainId ${chainId}. Supported: ${Object.keys(CHAIN_MAP).join(", ")}`
+    );
+  }
+  return chain;
+}
+
+// ─── Credential loading ─────────────────────────────────────────────────────
+
+/**
+ * Loads pre-decrypted delegation credentials from environment variables:
+ *   DELEGATED_WALLET_ID, DELEGATED_WALLET_ADDRESS,
+ *   DELEGATED_WALLET_API_KEY, DELEGATED_KEY_SHARE (JSON string)
+ */
+export function loadDelegationCredentials(): DelegationCredentials | null {
+  const walletId = process.env.DELEGATED_WALLET_ID;
+  const walletAddress = process.env.DELEGATED_WALLET_ADDRESS;
+  const walletApiKey = process.env.DELEGATED_WALLET_API_KEY;
+  const keyShareJson = process.env.DELEGATED_KEY_SHARE;
+
+  if (!walletId || !walletAddress || !walletApiKey || !keyShareJson) {
+    return null;
+  }
+
+  try {
+    return {
+      walletId,
+      walletAddress,
+      walletApiKey,
+      keyShare: JSON.parse(keyShareJson) as ServerKeyShare,
+    };
+  } catch {
+    console.warn("[wallet] Failed to parse DELEGATED_KEY_SHARE as JSON");
+    return null;
+  }
+}
+
+// ─── Delegated client singleton ─────────────────────────────────────────────
+
+let _delegatedClient: DelegatedEvmWalletClient | null = null;
+
+function getDelegatedEvmClient(): DelegatedEvmWalletClient {
+  if (!_delegatedClient) {
+    const environmentId = process.env.DYNAMIC_ENVIRONMENT_ID;
+    const apiKey = process.env.DYNAMIC_API_KEY;
+    if (!environmentId || !apiKey) {
+      throw new Error(
+        "DYNAMIC_ENVIRONMENT_ID and DYNAMIC_API_KEY are required for delegated signing"
+      );
+    }
+    _delegatedClient = createDelegatedEvmWalletClient({ environmentId, apiKey });
+  }
+  return _delegatedClient;
+}
+
+// ─── Sign + broadcast ───────────────────────────────────────────────────────
+
+/**
+ * Signs (via Dynamic MPC) and broadcasts a native-value transfer on the given
+ * EVM chain. Returns the transaction hash.
+ */
+export async function sendTransactionDelegated(
+  creds: DelegationCredentials,
+  chainId: number,
+  to: `0x${string}`,
+  value: bigint
+): Promise<string> {
+  const chain = getChainById(chainId);
+  const publicClient = createPublicClient({ chain, transport: http() });
+  const address = creds.walletAddress as `0x${string}`;
+
+  const nonce = await publicClient.getTransactionCount({ address });
+  const block = await publicClient.getBlock({ blockTag: "latest" });
+  const baseFee = block.baseFeePerGas ?? BigInt(30_000_000_000);
+  const maxPriorityFeePerGas = BigInt(1_500_000_000);
+  const maxFeePerGas = baseFee * 2n + maxPriorityFeePerGas;
+
+  let gas: bigint;
+  try {
+    const estimated = await publicClient.estimateGas({ account: address, to, value });
+    gas = (estimated * 12n) / 10n; // 20% buffer
+  } catch {
+    gas = BigInt(21_000);
+  }
+
+  const transaction: TransactionSerializable = {
+    type: "eip1559",
+    chainId,
+    to,
+    value,
+    nonce,
+    gas,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+  };
+
+  const signedTx = await delegatedSignTransaction(getDelegatedEvmClient(), {
+    walletId: creds.walletId,
+    walletApiKey: creds.walletApiKey,
+    keyShare: creds.keyShare,
+    transaction,
+  });
+
+  return publicClient.sendRawTransaction({
+    serializedTransaction: signedTx as `0x${string}`,
+  });
+}

--- a/examples/nodejs-langgraph-agent/tsconfig.json
+++ b/examples/nodejs-langgraph-agent/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2023"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

A minimal **LangGraph ReAct agent** (Claude Haiku 4.5) that acts through its own **Dynamic server-side MPC wallet**. The agent creates and owns its wallet entirely server-side — no user JWT, no delegation, no client-side approval flow required. On first run, a new MPC wallet is created and persisted to \`.wallet-state.json\`; subsequent runs reuse it.

## Tools

| Tool | What it does |
| --- | --- |
| `list_wallets` | Returns the agent's server wallet address. |
| `get_token_balances` | Native-token balances across EVM chains via on-chain RPC (viem). |
| `send_transaction` | Native transfer signed via Dynamic server-side MPC. **Always** gated behind a `y/N` confirm prompt. |

## Layout

```
src/wallet.ts   — DynamicEvmWalletClient init, .wallet-state.json persistence, sign + broadcast
src/tools.ts    — the three LangChain tools
src/agent.ts    — createReactAgent loop + system prompt
src/index.ts    — interactive terminal REPL
src/confirm.ts  — confirmation prompt for sensitive actions
```

## Notes

- Matches the repo's `nodejs-*` conventions: pnpm + `tsx`, `dotenv`, exact-pinned dependencies, `.example.env`.
- Only `.example.env` (placeholders) is tracked; real `.env` and `.wallet-state.json` are gitignored.
- `pnpm typecheck` passes; runtime startup verified (creates/loads the server wallet, then runs the REPL).

## Security considerations

- No secrets committed — `.env*` and `.wallet-state.json` are gitignored, only placeholder `.example.env` is tracked.
- The agent never holds raw private keys; all signing goes through Dynamic's server-side MPC.
- `.wallet-state.json` contains the server key share (written with `0o600` permissions) — treated like a private key.
- `send_transaction` requires explicit `y/N` user confirmation before broadcasting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)